### PR TITLE
fix(docs): correct swagger paths and gh-pages deploy

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -11,14 +11,16 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
 
 concurrency:
-  group: deploy-docs-${{ github.ref }}
-  cancel-in-progress: true
+  group: pages
+  cancel-in-progress: false
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     if: github.repository == 'redai-infra/Relax'
     steps:
@@ -45,11 +47,25 @@ jobs:
           npm install --no-audit --no-fund --include=optional
           npm install --no-audit --no-fund --no-save @rollup/rollup-linux-x64-gnu
 
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
       - name: Build VitePress site
         run: npm run docs:build
 
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: docs/.vitepress/dist
+          path: docs/.vitepress/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.repository == 'redai-infra/Relax'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ If you find Relax useful in your research, please cite:
 @software{relax2026,
   title  = {Relax: An Asynchronous Reinforcement Learning Engine for Omni-Modal Post-Training at Scale},
   author = {Relax Contributors},
-  url    = {https://github.com/redai-infra/Relax},
+  url    = {https://arxiv.org/abs/2604.11554},
   year   = {2026}
 }
 ```

--- a/README_zh.md
+++ b/README_zh.md
@@ -260,7 +260,7 @@ ______________________________________________________________________
 @software{relax2026,
   title  = {Relax: An Asynchronous Reinforcement Learning Engine for Omni-Modal Post-Training at Scale},
   author = {Relax Contributors},
-  url    = {https://github.com/redai-infra/Relax},
+  url    = {https://arxiv.org/abs/2604.11554},
   year   = {2026}
 }
 ```

--- a/docs/en/api/actor-fwd.md
+++ b/docs/en/api/actor-fwd.md
@@ -33,7 +33,7 @@ The ActorFwd runs a background loop that:
 
 ## HTTP Endpoints
 
-<SwaggerUI specUrl="/relax/openapi/actor_fwd.json" />
+<SwaggerUI specUrl="/Relax/openapi/actor_fwd.json" />
 
 ## Source
 

--- a/docs/en/api/actor.md
+++ b/docs/en/api/actor.md
@@ -30,7 +30,7 @@ The Actor runs a background training loop that:
 
 ## HTTP Endpoints
 
-<SwaggerUI specUrl="/relax/openapi/actor.json" />
+<SwaggerUI specUrl="/Relax/openapi/actor.json" />
 
 ## Source
 

--- a/docs/en/api/genrm.md
+++ b/docs/en/api/genrm.md
@@ -34,7 +34,7 @@ When colocated with the Actor (sharing GPU resources), GenRM supports offload/on
 
 ## HTTP Endpoints
 
-<SwaggerUI specUrl="/relax/openapi/genrm.json" />
+<SwaggerUI specUrl="/Relax/openapi/genrm.json" />
 
 ## Source
 

--- a/docs/en/api/rollout.md
+++ b/docs/en/api/rollout.md
@@ -35,7 +35,7 @@ In fully-async mode, the Rollout service coordinates with the Actor for weight u
 
 ## HTTP Endpoints
 
-<SwaggerUI specUrl="/relax/openapi/rollout.json" />
+<SwaggerUI specUrl="/Relax/openapi/rollout.json" />
 
 ## Source
 

--- a/docs/zh/api/actor-fwd.md
+++ b/docs/zh/api/actor-fwd.md
@@ -33,7 +33,7 @@ ActorFwd 运行后台循环：
 
 ## HTTP 端点
 
-<SwaggerUI specUrl="/relax/openapi/actor_fwd.json" />
+<SwaggerUI specUrl="/Relax/openapi/actor_fwd.json" />
 
 ## 源码
 

--- a/docs/zh/api/actor.md
+++ b/docs/zh/api/actor.md
@@ -30,7 +30,7 @@ Actor 运行后台训练循环：
 
 ## HTTP 端点
 
-<SwaggerUI specUrl="/relax/openapi/actor.json" />
+<SwaggerUI specUrl="/Relax/openapi/actor.json" />
 
 ## 源码
 

--- a/docs/zh/api/genrm.md
+++ b/docs/zh/api/genrm.md
@@ -34,7 +34,7 @@ GenRM（生成式奖励模型）服务提供基于 LLM 的响应评估。它以 
 
 ## HTTP 端点
 
-<SwaggerUI specUrl="/relax/openapi/genrm.json" />
+<SwaggerUI specUrl="/Relax/openapi/genrm.json" />
 
 ## 源码
 

--- a/docs/zh/api/rollout.md
+++ b/docs/zh/api/rollout.md
@@ -35,7 +35,7 @@ Rollout 运行后台循环：
 
 ## HTTP 端点
 
-<SwaggerUI specUrl="/relax/openapi/rollout.json" />
+<SwaggerUI specUrl="/Relax/openapi/rollout.json" />
 
 ## 源码
 


### PR DESCRIPTION
# 🐛 Bug Fix

## Fix swagger spec 404 on GitHub Pages

- Update all 8 API doc SwaggerUI specUrl from /relax/openapi/ to /Relax/openapi/ to match VitePress base

---

# 🔧 CI/CD

## Switch docs deployment to GitHub Actions Pages

- Replace peaceiris/actions-gh-pages force-push flow with native actions/configure-pages + upload-pages-artifact + deploy-pages
- Split into build and deploy jobs with github-pages environment
- Drop contents:write, add pages:write and id-token:write

---

# 📝 Documentation

## Point citation url to arXiv

- Update bibtex url in README.md and README_zh.md to https://arxiv.org/abs/2604.11554

## What

<!-- What changes does this PR introduce? -->

## Why

<!-- Why are these changes needed? Link related issues with "Fixes #123" or "Relates to #456". -->

## How

<!-- How do the changes work? Describe the technical approach. -->

## Testing

<!-- How were the changes tested? Include commands, test results, or screenshots. -->

- [ ] `pre-commit run --all-files` passes
- [ ] Tests pass (`pytest tests/`)
- [ ] New tests added (if applicable)
- [ ] Documentation updated (if applicable)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Screenshots / Logs

<!-- If applicable, add screenshots or log output to help explain the changes. -->
