### PR TITLE
[wip]feat(qwen35-9b): add NPU training support for Qwen3.5-9B

### DIFF
--- a/docker/Dockerfile.npu.qwen35-9b
+++ b/docker/Dockerfile.npu.qwen35-9b
@@ -1,0 +1,83 @@
+#
+FROM quay.io/ascend/vllm-ascend:v0.18.0-a3
+
+COPY ./docker/npu_patch /workspace/patch
+COPY . /workspace/Relax
+WORKDIR /workspace
+ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
+
+RUN sed -i 's/archive.ubuntu.com/mirrors.tuna.tsinghua.edu.cn/g' /etc/apt/sources.list && \
+    sed -i 's/security.ubuntu.com/mirrors.tuna.tsinghua.edu.cn/g' /etc/apt/sources.list
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y --no-install-recommends \
+    build-essential patchelf tmux net-tools htop nano iputils-ping \
+    autoconf automake libatlas-base-dev libgoogle-glog-dev libbz2-dev libc-ares2 \
+    libleveldb-dev liblmdb-dev libprotobuf-dev libsnappy-dev libtool nasm protobuf-compiler pkg-config unzip sox \
+    libsndfile1 libpng-dev libhdf5-dev gfortran rapidjson-dev ninja-build libedit-dev rsync
+
+RUN apt-get install -y locales tzdata && \
+    locale-gen "$LANG" && update-locale LANG="$LANG" LC_ALL="$LC_ALL" && \
+    ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+RUN apt-get install -y --no-install-recommends \
+    libgl1-mesa-glx \
+    libglib2.0-0 \
+    libsm6 \
+    libxext6 \
+    libxrender-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip config set global.index-url ${PIP_INDEX_URL} && \
+    git config --global http.sslverify false && \
+    git config --global http.postBuffer 2147483648
+
+RUN git clone https://gitcode.com/Ascend/MindSpeed.git /workspace/MindSpeed && \
+    git clone https://github.com/NVIDIA/Megatron-LM.git /workspace/Megatron-LM && \
+    git clone https://github.com/coding-famer/Megatron-Bridge-slime.git /workspace/Megatron-Bridge && \
+    cp -rf /workspace/MindSpeed/mindspeed/ops/triton /workspace
+
+RUN cd /workspace/MindSpeed && git checkout fc63de5c && pip install -r requirements.txt && pip install -e . && \
+    cd /workspace/Megatron-LM  && git checkout 3714d81d4 && pip install -e . && \
+    cd /workspace/Megatron-Bridge && git checkout qwen35 && \
+    mv /workspace/triton /workspace/MindSpeed/mindspeed/ops
+
+RUN git clone https://github.com/sgl-project/sgl-kernel-npu.git /workspace/sgl-kernel-npu && \
+    git clone https://github.com/sgl-project/sglang.git /workspace/sglang
+
+RUN git clone https://gitcode.com/Ascend/pytorch.git /workspace/pytorch && \
+    cd /workspace/pytorch && git checkout v2.9.0-7.3.0 && bash ci/build.sh --python=3.11 && \
+    pip install /workspace/pytorch/dist/torch_npu*_aarch64.whl
+
+RUN cd /workspace/sglang/python && \
+    git fetch origin pull/23815/head:pr-23815 && \
+    git checkout pr-23815 && \
+    rm -rf pyproject.toml && \
+    mv pyproject_npu.toml pyproject.toml && \
+    pip install -v -e .[all_npu]
+
+RUN cd /workspace/sgl-kernel-npu && \
+    git checkout 2026.04.15.rc3 && \
+    bash build.sh && \
+    pip install output/*.whl
+
+RUN cd /workspace/Relax && pip install -r requirements.txt && pip install -e .
+
+RUN pip install --no-cache-dir tensordict==0.10.0 pyvers==0.1.0 --no-deps && \
+    pip install "transferqueue @ git+https://github.com/redai-infra/TransferQueue.git" --no-deps -i https://pypi.tuna.tsinghua.edu.cn/simple && \
+    pip install nvidia-modelopt && \
+    pip install setuptools==79.0.1 fla-core flash-linear-attention && \
+    cd "$(python3 -m pip show deep-ep | awk '/^Location:/ {print $2}')" && ln -sf deep_ep/deep_ep_cpp*.so
+
+RUN cd /workspace/MindSpeed && \
+    patch -p1 < /workspace/patch/mindspeed-9b.patch && \
+    cd /workspace/Megatron-Bridge && \
+    patch -p1 < /workspace/patch/megatron-bridge-9b.patch && \
+    cd /workspace/Megatron-LM && \
+    patch -p1 < /workspace/patch/megatron-lm-9b.patch && \
+    cd /workspace/sgl-kernel-npu && \
+    patch -p1 < /workspace/patch/sgl-kernel-npu-9b.patch && \
+    rm -rf /workspace/patch
+
+ENV PYTHONPATH=/workspace/Megatron-Bridge/src:/workspace/MindSpeed:/workspace/Megatron-LM:$PYTHONPATH
+
+CMD ["/bin/bash"]

--- a/docker/npu_patch/megatron-bridge-9b.patch
+++ b/docker/npu_patch/megatron-bridge-9b.patch
@@ -1,0 +1,116 @@
+From 7a54eb5d5b3603d469db0014e6947555cc6d3245 Mon Sep 17 00:00:00 2001
+From: cjy0x <chenjunyi10@huawei.com>
+Date: Sat, 16 May 2026 22:47:57 +0800
+Subject: [PATCH] add mindspeed mapping & remove nvtx
+
+Signed-off-by: cjy0x <chenjunyi10@huawei.com>
+---
+ src/megatron/bridge/models/conversion/param_mapping.py | 10 ++++++++--
+ .../bridge/models/qwen_vl/modelling_qwen3_vl/model.py  |  6 ------
+ 2 files changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/src/megatron/bridge/models/conversion/param_mapping.py b/src/megatron/bridge/models/conversion/param_mapping.py
+index d0c0d318..4feb3ea3 100644
+--- a/src/megatron/bridge/models/conversion/param_mapping.py
++++ b/src/megatron/bridge/models/conversion/param_mapping.py
+@@ -1078,16 +1078,21 @@ class AutoMapping(MegatronParamMapping[torch.Tensor]):
+         "column": {
+             "ColumnParallelLinear",
+             "TEColumnParallelLinear",
++            "MindSpeedTEColumnParallelLinear",
+             "TELayerNormColumnParallelLinear",
++            "MindSpeedTELayerNormColumnParallelLinear",
+             "TEColumnParallelGroupedLinear",
++            "MindSpeedTEColumnParallelGroupedLinear",
+             "VocabParallelEmbedding",
+             "DotProductAttention",  # for attention sink only
+             "TEDotProductAttention",  # for attention sink only
++            "MindSpeedTEDotProductAttention",
+         },
+         "row": {
+             "RowParallelLinear",
+             "TERowParallelLinear",
+             "TERowParallelGroupedLinear",
++            "MindSpeedTERowParallelGroupedLinear",
+         },
+         "replicated": {
+             # Normalization layers
+@@ -1100,6 +1105,7 @@ class AutoMapping(MegatronParamMapping[torch.Tensor]):
+             # Other non-parallel modules
+             "IdentityOp",
+             "TopKRouter",
++            "PTNorm",
+         },
+     }
+ 
+@@ -1155,7 +1161,7 @@ class AutoMapping(MegatronParamMapping[torch.Tensor]):
+         # Handle fused modules like TELayerNormColumnParallelLinear
+         # These modules have both column-parallel weights (weight, bias)
+         # and replicated layer norm weights (layer_norm_weight, layer_norm_bias)
+-        if module_type == "TELayerNormColumnParallelLinear":
++        if module_type == "TELayerNormColumnParallelLinear" or module_type == "MindSpeedTELayerNormColumnParallelLinear":
+             # Check the actual parameter name to determine the correct parallelism type
+             if self.megatron_param and (
+                 self.megatron_param.endswith("layer_norm_weight") or self.megatron_param.endswith("layer_norm_bias")
+@@ -1186,7 +1192,7 @@ class AutoMapping(MegatronParamMapping[torch.Tensor]):
+             return "replicated"
+ 
+         # Check parallel_mode for TELinear
+-        if module_type == "TELinear":
++        if module_type == "TELinear" or module_type == "MindSpeedTELinear":
+             if module.parallel_mode == "column":
+                 return "column"
+             elif module.parallel_mode == "row":
+diff --git a/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/model.py b/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/model.py
+index 5d520e23..77eb7b15 100644
+--- a/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/model.py
++++ b/src/megatron/bridge/models/qwen_vl/modelling_qwen3_vl/model.py
+@@ -288,8 +288,6 @@ class Qwen3VLModel(MegatronModule):
+         # position ids is computed within the model
+         position_ids = None
+ 
+-        torch.cuda.nvtx.range_push("Qwen3VLModel.forward.pre_process")
+-
+         cp_rank = self.pg_collection.cp.rank()
+         cp_size = self.pg_collection.cp.size()
+ 
+@@ -478,9 +476,6 @@ class Qwen3VLModel(MegatronModule):
+                 attention_mask = None
+                 self.language_model.rotary_pos_emb.is_thd_format = True
+ 
+-        torch.cuda.nvtx.range_pop()
+-        torch.cuda.nvtx.range_push("Qwen3VLModel.forward.language_model")
+-
+         output = self.language_model(
+             input_ids=None,
+             position_ids=position_ids,  # None in encoder
+@@ -495,6 +490,5 @@ class Qwen3VLModel(MegatronModule):
+             **(extra_block_kwargs or {}),
+             **kwargs,
+         )
+-        torch.cuda.nvtx.range_pop()
+ 
+         return output
+-- 
+2.34.1
+
+diff --git a/src/megatron/bridge/models/conversion/utils.py b/src/megatron/bridge/models/conversion/utils.py
+index 5a66e719..3d411c17 100644
+--- a/src/megatron/bridge/models/conversion/utils.py
++++ b/src/megatron/bridge/models/conversion/utils.py
+@@ -203,6 +203,15 @@ def remove_non_pickleables(obj, max_depth: int = 3, current_depth: int = 0):
+ 
+             # Recursively clean attribute
+             cleaned_value = remove_non_pickleables(attr_value, max_depth, current_depth + 1)
++            if hasattr(cleaned_obj, '__setattr__'):
++                try:
++                    setattr(cleaned_obj, attr_name, cleaned_value)
++                except (ValueError, TypeError) as e:
++                    # 跳过 OmegaConf 不支持的类型
++                    if "Unions of containers" in str(e):
++                        print(f"Skipping attribute '{attr_name}' due to Union type")
++                        continue
++                    raise
+ 
+             # Set the cleaned value (or None if it was removed)
+             setattr(cleaned_obj, attr_name, cleaned_value)

--- a/docker/npu_patch/megatron-lm-9b.patch
+++ b/docker/npu_patch/megatron-lm-9b.patch
@@ -1,0 +1,24 @@
+diff --git a/megatron/core/ssm/gated_delta_net.py b/megatron/core/ssm/gated_delta_net.py
+index dfa6e4c35..11d838286 100644
+--- a/megatron/core/ssm/gated_delta_net.py
++++ b/megatron/core/ssm/gated_delta_net.py
+@@ -37,8 +37,8 @@ from megatron.core.utils import deprecate_inference_params, nvtx_range_pop, nvtx
+ # from .gated_delta_net_context_parallel import GatedDeltaNetContextParallel
+ 
+ try:
+-    from fla.modules.l2norm import l2norm
+-    from fla.ops.gated_delta_rule import chunk_gated_delta_rule
++    from mindspeed.ops.triton.l2norm import l2norm
++    from mindspeed.ops.chunk_gated_delta_rule import chunk_gated_delta_rule
+ 
+     HAVE_FLA = True
+ except ImportError:
+@@ -372,7 +372,7 @@ class GatedDeltaNet(MegatronModule):
+         nvtx_range_pop(suffix="g_and_beta")
+ 
+         nvtx_range_push(suffix="gated_delta_rule")
+-        if self.config.deterministic_mode:
++        if not HAVE_FLA:
+             core_attn_out, last_recurrent_state = torch_chunk_gated_delta_rule(
+                 query,
+                 key,

--- a/docker/npu_patch/mindspeed-9b.patch
+++ b/docker/npu_patch/mindspeed-9b.patch
@@ -1,0 +1,794 @@
+diff --git a/mindspeed/arguments.py b/mindspeed/arguments.py
+index c624fd0a..149531f0 100644
+--- a/mindspeed/arguments.py
++++ b/mindspeed/arguments.py
+@@ -81,21 +81,21 @@ def _add_deepseek_args(parser):
+ 
+ def _add_profile_args(parser):
+     group = parser.add_argument_group(title='profile')
+-    group.add_argument("--profile-level", type=str, default='level0',
+-                       choices=['level0', 'level1', 'level2'],
+-                       help="Profile level default level0.")
+-    group.add_argument("--profile-with-cpu", action='store_true', default=False,
+-                       help="Profile with cpu info.")
+-    group.add_argument("--profile-with-stack", action='store_true', default=False,
+-                       help="Profile without stack info.")
+-    group.add_argument("--profile-with-memory", action='store_true', default=False,
+-                       help="Profile without memory info.")
+-    group.add_argument("--profile-record-shapes", action='store_true', default=False,
+-                       help="Profile record shape info.")
+-    group.add_argument("--profile-save-path", type=str, default='./profile_dir',
+-                       help="Profile save path.")
+-    group.add_argument('--profile-ranks', nargs='+', type=int, default=[-1],
+-                       help='Global ranks to profile.The default value of -1 means to profile all ranks')
++    # group.add_argument("--profile-level", type=str, default='level0',
++    #                    choices=['level0', 'level1', 'level2'],
++    #                    help="Profile level default level0.")
++    # group.add_argument("--profile-with-cpu", action='store_true', default=False,
++    #                    help="Profile with cpu info.")
++    # group.add_argument("--profile-with-stack", action='store_true', default=False,
++    #                    help="Profile without stack info.")
++    # group.add_argument("--profile-with-memory", action='store_true', default=False,
++    #                    help="Profile without memory info.")
++    # group.add_argument("--profile-record-shapes", action='store_true', default=False,
++    #                    help="Profile record shape info.")
++    # group.add_argument("--profile-save-path", type=str, default='./profile_dir',
++    #                    help="Profile save path.")
++    # group.add_argument('--profile-ranks', nargs='+', type=int, default=[-1],
++    #                    help='Global ranks to profile.The default value of -1 means to profile all ranks')
+     return parser
+ 
+ 
+diff --git a/mindspeed/core/fusions/fused_rms_norm.py b/mindspeed/core/fusions/fused_rms_norm.py
+index 001efcca..88fea6d1 100644
+--- a/mindspeed/core/fusions/fused_rms_norm.py
++++ b/mindspeed/core/fusions/fused_rms_norm.py
+@@ -31,10 +31,13 @@ class RMSNorm(torch.nn.Module):
+ 
+     def unfused_rmsnorm(self, x):
+         output = self._norm(x.float()).type_as(x)
++        if self.config.layernorm_zero_centered_gamma:
++            return output * (1 + self.weight)
+         return output * self.weight
+ 
+     def fused_rmsnorm(self, x):
+-        return torch_npu.npu_rms_norm(x, self.weight, epsilon=self.eps)[0]
++        weight = 1 + self.weight if self.config.layernorm_zero_centered_gamma else self.weight
++        return torch_npu.npu_rms_norm(x, weight, epsilon=self.eps)[0]
+ 
+     def forward(self, x):
+         if self.config.use_fused_rmsnorm:
+diff --git a/mindspeed/core/fusions/fused_rope.py b/mindspeed/core/fusions/fused_rope.py
+index a6f02e07..267fad59 100644
+--- a/mindspeed/core/fusions/fused_rope.py
++++ b/mindspeed/core/fusions/fused_rope.py
+@@ -126,5 +126,6 @@ def apply_rotary_pos_emb(
+         freqs,
+         rotary_interleaved=config.rotary_interleaved,
+         multi_latent_attention=config.multi_latent_attention,
+-        mscale=mscale
++        mscale=mscale,
++        cp_group=cp_group,
+     )
+diff --git a/mindspeed/core/megatron_basic/arguments_basic.py b/mindspeed/core/megatron_basic/arguments_basic.py
+index 8ea25b9f..97c0a13e 100644
+--- a/mindspeed/core/megatron_basic/arguments_basic.py
++++ b/mindspeed/core/megatron_basic/arguments_basic.py
+@@ -113,3 +113,27 @@ def transformer_config_init_wrapper(fn):
+         fn(self, *args, **known_config)
+ 
+     return wrapper
++
++
++def transformer_config_init_subclass(cls, **kwargs):
++    mutable_types = (list, dict, set, bytearray)
++    unknown_config = {}
++    full_args = vars(get_full_args()).copy()
++    full_args.update(kwargs)
++
++    config_key = inspect.signature(cls).parameters
++    for key, value in full_args.items():
++        if key not in config_key:
++            unknown_config[key] = value
++
++    for key, value in unknown_config.items():
++        if not hasattr(cls, key):
++            cls.__annotations__[key] = type(value)
++            value = field(default_factory=value) if callable(value) and not isinstance(value, type) else value
++            if callable(value) and not isinstance(value, type):
++                value = field(default_factory=value)
++            elif type(value) in mutable_types:
++                value = field(default_factory=lambda: value)
++            else:
++                value = value
++            setattr(cls, key, value)
+\ No newline at end of file
+diff --git a/mindspeed/features_manager/functional/profile.py b/mindspeed/features_manager/functional/profile.py
+index 6450b41c..95b0de25 100644
+--- a/mindspeed/features_manager/functional/profile.py
++++ b/mindspeed/features_manager/functional/profile.py
+@@ -10,20 +10,21 @@ class ProfileFeature(MindSpeedFeature):
+         super().__init__('profile', optimization_level=2)
+ 
+     def register_args(self, parser: ArgumentParser):
+-        group = parser.add_argument_group(title=self.feature_name)
+-        group.add_argument("--profile-level", type=str, default='level0',
+-                           choices=['level0', 'level1', 'level2'],
+-                           help="Profile level default level0.")
+-        group.add_argument("--profile-with-cpu", action='store_true', default=False,
+-                           help="Profile with cpu info.")
+-        group.add_argument("--profile-with-stack", action='store_true', default=False,
+-                           help="Profile with stack info.")
+-        group.add_argument("--profile-with-memory", action='store_true', default=False,
+-                           help="Profile with memory info.")
+-        group.add_argument("--profile-record-shapes", action='store_true', default=False,
+-                           help="Profile record shape info.")
+-        group.add_argument("--profile-save-path", type=str, default='./profile_dir',
+-                           help="Profile save path.")
++        pass
++        # group = parser.add_argument_group(title=self.feature_name)
++        # group.add_argument("--profile-level", type=str, default='level0',
++        #                    choices=['level0', 'level1', 'level2'],
++        #                    help="Profile level default level0.")
++        # group.add_argument("--profile-with-cpu", action='store_true', default=False,
++        #                    help="Profile with cpu info.")
++        # group.add_argument("--profile-with-stack", action='store_true', default=False,
++        #                    help="Profile with stack info.")
++        # group.add_argument("--profile-with-memory", action='store_true', default=False,
++        #                    help="Profile with memory info.")
++        # group.add_argument("--profile-record-shapes", action='store_true', default=False,
++        #                    help="Profile record shape info.")
++        # group.add_argument("--profile-save-path", type=str, default='./profile_dir',
++        #                    help="Profile save path.")
+ 
+     def register_patches(self, patch_manager, args):
+         from mindspeed.functional.profile.adaptor import train_wrapper, train_step_wrapper
+diff --git a/mindspeed/features_manager/megatron_basic/megatron_basic.py b/mindspeed/features_manager/megatron_basic/megatron_basic.py
+index 355913e1..36360d11 100644
+--- a/mindspeed/features_manager/megatron_basic/megatron_basic.py
++++ b/mindspeed/features_manager/megatron_basic/megatron_basic.py
+@@ -43,9 +43,11 @@ class MegatronBasicFeature(MindSpeedFeature):
+ 
+     def register_mcore_basic_patches(self, pm, args):
+         # configuration patches
+-        from mindspeed.core.megatron_basic.arguments_basic import transformer_config_init_wrapper, transformer_config_post_init_wrapper
++        from mindspeed.core.megatron_basic.arguments_basic import (transformer_config_init_wrapper,
++                                                                   transformer_config_post_init_wrapper,
++                                                                   transformer_config_init_subclass)
+         pm.register_patch("megatron.core.transformer.transformer_config.TransformerConfig.__init__", transformer_config_init_wrapper)
+-        pm.register_patch("megatron.core.transformer.transformer_config.MLATransformerConfig.__init__", transformer_config_init_wrapper)
++        pm.register_patch("megatron.core.transformer.transformer_config.TransformerConfig.__init_subclass__", classmethod(transformer_config_init_subclass))
+         pm.register_patch("megatron.core.transformer.transformer_config.TransformerConfig.__post_init__", transformer_config_post_init_wrapper)
+ 
+         # initialization patches
+diff --git a/mindspeed/features_manager/moe/moe_zero_memory.py b/mindspeed/features_manager/moe/moe_zero_memory.py
+index 4d95e64e..f22c53b8 100644
+--- a/mindspeed/features_manager/moe/moe_zero_memory.py
++++ b/mindspeed/features_manager/moe/moe_zero_memory.py
+@@ -24,17 +24,18 @@ class MoEZeroMemoryFeature(MindSpeedFeature):
+ 
+     def pre_validate_args(self, args):
+         #Zero Memory check.
+-        if args.moe_zero_memory_num_layers is not None:
++        if getattr(args, 'moe_zero_memory_num_layers', None) is not None:
+             num_layers_per_pipeline_stage = args.num_layers // args.pipeline_model_parallel_size
+             if args.moe_zero_memory_num_layers < 0 or args.moe_zero_memory_num_layers > num_layers_per_pipeline_stage:
+                 raise AssertionError('`--moe-zero-memory-num-layers` must be between 0 and num layers per pipeline stage')
+             if args.moe_zero_memory == "disable":
+                 raise AssertionError('`--moe-zero-memory` must be enabled when using `--moe-zero-memory-num-layers`')
+-        if args.moe_zero_memory != "disable" and not (args.moe_alltoall_overlap_comm or args.moe_fb_overlap):
++        if getattr(args, 'moe_zero_memory', "disable") != "disable" and not \
++            (getattr(args, 'moe_alltoall_overlap_comm', None) or getattr(args, 'moe_fb_overlap', None)):
+             raise AssertionError('`--moe-zero-memory` only support `--moe-alltoall-overlap-comm` or `--moe-fb-overlap` for now.')
+ 
+     def register_patches(self, patch_manager, args):
+-        if args.moe_zero_memory != 'disable' and args.moe_alltoall_overlap_comm:
++        if getattr(args, 'moe_zero_memory', "disable") and getattr(args, 'moe_alltoall_overlap_comm', None):
+             from mindspeed.core.transformer.moe.moe_feature.overlap.experts import zero_memory_shared_expert_mlp_forward
+             patch_manager.register_patch(
+                 'megatron.core.transformer.moe.shared_experts.SharedExpertMLP.forward',
+diff --git a/mindspeed/megatron_adaptor.py b/mindspeed/megatron_adaptor.py
+index f14b231d..4615590e 100644
+--- a/mindspeed/megatron_adaptor.py
++++ b/mindspeed/megatron_adaptor.py
+@@ -57,6 +57,7 @@ def delete_lock_file():
+ def repatch(args):
+     MindSpeedFeaturesManager.remove_patches()
+     full_args = get_full_args()
++    args = vars(args)
+     for k, v in args.items():
+         setattr(full_args, k, v)
+     MindSpeedFeaturesManager.apply_features_pre_patches(full_args)
+diff --git a/mindspeed/ops/chunk_gated_delta_rule.py b/mindspeed/ops/chunk_gated_delta_rule.py
+new file mode 100644
+index 00000000..04b85e36
+--- /dev/null
++++ b/mindspeed/ops/chunk_gated_delta_rule.py
+@@ -0,0 +1,468 @@
++# Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
++# Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
++# Copyright (c) 2025, HUAWEI CORPORATION.  All rights reserved.
++
++import warnings
++from typing import Optional
++
++import torch
++import torch.nn.functional as F
++
++from mindspeed.ops.triton.l2norm import l2norm_bwd, l2norm_fwd, l2norm
++from mindspeed.ops.triton.chunk_delta_h import chunk_gated_delta_rule_bwd_dhu, chunk_gated_delta_rule_fwd_h
++from mindspeed.ops.triton.chunk_o import chunk_bwd_dqkwg, chunk_bwd_dv_local, chunk_fwd_o
++from mindspeed.ops.triton.chunk_scaled_dot_kkt import chunk_scaled_dot_kkt_fwd
++from mindspeed.ops.triton.wy_fast import prepare_wy_repr_bwd, recompute_w_u_fwd
++from mindspeed.ops.triton.solve_tril import solve_tril
++from mindspeed.ops.triton.cumsum import chunk_local_cumsum
++from mindspeed.ops.triton.utils import autocast_custom_bwd, autocast_custom_fwd, input_guard
++
++
++def chunk_gated_delta_rule_fwd(
++    q: torch.Tensor,
++    k: torch.Tensor,
++    v: torch.Tensor,
++    g: torch.Tensor,
++    beta: torch.Tensor,
++    scale: float,
++    initial_state: torch.Tensor,
++    output_final_state: bool,
++    cu_seqlens: Optional[torch.LongTensor] = None,
++    chunk_size: int = 64,
++):
++    g = chunk_local_cumsum(g, chunk_size=chunk_size, cu_seqlens=cu_seqlens, head_first=False)
++    # obtain WY representation. u is actually the new v.
++    A = chunk_scaled_dot_kkt_fwd(
++        k=k,
++        g=g,
++        beta=beta,
++        cu_seqlens=cu_seqlens,
++        chunk_size=chunk_size,
++        output_dtype=torch.float32
++    )
++    A = solve_tril(
++        A=A,
++        cu_seqlens=cu_seqlens,
++        output_dtype=k.dtype
++    )
++    w, u = recompute_w_u_fwd(
++        k=k,
++        v=v,
++        beta=beta,
++        A=A,
++        g=g,
++        cu_seqlens=cu_seqlens,
++    )
++    h, v_new, final_state = chunk_gated_delta_rule_fwd_h(
++        k=k,
++        w=w,
++        u=u,
++        g=g,
++        initial_state=initial_state,
++        output_final_state=output_final_state,
++        chunk_size=chunk_size,
++        cu_seqlens=cu_seqlens,
++    )
++    o = chunk_fwd_o(
++        q=q,
++        k=k,
++        v=v_new,
++        h=h,
++        g=g,
++        scale=scale,
++        cu_seqlens=cu_seqlens,
++        chunk_size=chunk_size,
++    )
++    return g, o, A, final_state
++
++
++def chunk_gated_delta_rule_bwd(
++    q: torch.Tensor,
++    k: torch.Tensor,
++    v: torch.Tensor,
++    g: torch.Tensor,
++    beta: torch.Tensor,
++    A: torch.Tensor,
++    scale: float,
++    initial_state: torch.Tensor,
++    do: torch.Tensor,
++    dht: torch.Tensor,
++    cu_seqlens: Optional[torch.LongTensor] = None,
++    chunk_size: int = 64,
++):
++    w, u = recompute_w_u_fwd(
++        k=k,
++        v=v,
++        beta=beta,
++        A=A,
++        g=g,
++        cu_seqlens=cu_seqlens,
++    )
++    h, v_new, _ = chunk_gated_delta_rule_fwd_h(
++        k=k,
++        w=w,
++        u=u,
++        g=g,
++        initial_state=initial_state,
++        output_final_state=False,
++        cu_seqlens=cu_seqlens,
++        chunk_size=chunk_size,
++    )
++    dv = chunk_bwd_dv_local(
++        q=q,
++        k=k,
++        g=g,
++        do=do,
++        scale=scale,
++        cu_seqlens=cu_seqlens,
++        chunk_size=chunk_size,
++    )
++    dh, dh0, dv = chunk_gated_delta_rule_bwd_dhu(
++        q=q,
++        k=k,
++        w=w,
++        g=g,
++        h0=initial_state,
++        dht=dht,
++        do=do,
++        dv=dv,
++        scale=scale,
++        cu_seqlens=cu_seqlens,
++        chunk_size=chunk_size,
++    )
++    dq, dk, dw, dg = chunk_bwd_dqkwg(
++        q=q,
++        k=k,
++        v=v_new,
++        w=w,
++        g=g,
++        h=h,
++        dv=dv,
++        do=do,
++        dh=dh,
++        chunk_size=chunk_size,
++        scale=scale,
++        cu_seqlens=cu_seqlens,
++    )
++    dk2, dv, db, dg2 = prepare_wy_repr_bwd(
++        k=k,
++        v=v,
++        beta=beta,
++        g=g,
++        A=A,
++        dw=dw,
++        du=dv,
++        cu_seqlens=cu_seqlens,
++        chunk_size=chunk_size
++    )
++    dk.add_(dk2)
++    dg.add_(dg2)
++    if dg.dtype != torch.float32:
++        raise ValueError(
++            f"dg current type is {dg.dtype} , should be float32"
++        )
++    dg = chunk_local_cumsum(dg, chunk_size=chunk_size, reverse=True, cu_seqlens=cu_seqlens, head_first=False)
++    return dq, dk, dv, db, dg, dh0
++
++
++class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
++
++    @staticmethod
++    @input_guard
++    @autocast_custom_fwd
++    def forward(
++        ctx,
++        q: torch.Tensor,
++        k: torch.Tensor,
++        v: torch.Tensor,
++        g: torch.Tensor,
++        beta: torch.Tensor,
++        scale: float,
++        initial_state: torch.Tensor,
++        output_final_state: bool,
++        cu_seqlens: Optional[torch.LongTensor] = None,
++        use_qk_l2norm_in_kernel: bool = False,
++        chunk_size: int = 64,
++    ):
++        if use_qk_l2norm_in_kernel:
++            q, q_rstd = l2norm_fwd(q)
++            k, k_rstd = l2norm_fwd(k)
++        else:
++            q_rstd, k_rstd = None, None
++
++        g, o, A, final_state = chunk_gated_delta_rule_fwd(
++            q=q,
++            k=k,
++            v=v,
++            g=g,
++            beta=beta,
++            scale=scale,
++            initial_state=initial_state,
++            output_final_state=output_final_state,
++            cu_seqlens=cu_seqlens,
++            chunk_size=chunk_size
++        )
++        ctx.save_for_backward(q, q_rstd, k, k_rstd, v, g, beta, A, initial_state, cu_seqlens)
++        ctx.scale = scale
++        ctx.use_qk_l2norm_in_kernel = use_qk_l2norm_in_kernel
++        ctx.chunk_size = chunk_size
++        return o.to(q.dtype), final_state
++
++    @staticmethod
++    @input_guard
++    @autocast_custom_bwd
++    def backward(
++        ctx,
++        do: torch.Tensor,
++        dht: torch.Tensor
++    ):
++        q, q_rstd, k, k_rstd, v, g, beta, A, initial_state, cu_seqlens= ctx.saved_tensors
++        dq, dk, dv, db, dg, dh0 = chunk_gated_delta_rule_bwd(
++            q=q,
++            k=k,
++            v=v,
++            g=g,
++            beta=beta,
++            A=A,
++            scale=ctx.scale,
++            initial_state=initial_state,
++            do=do,
++            dht=dht,
++            cu_seqlens=cu_seqlens,
++            chunk_size=ctx.chunk_size,
++        )
++        if ctx.use_qk_l2norm_in_kernel:
++            dq = l2norm_bwd(q, q_rstd, dq)
++            dk = l2norm_bwd(k, k_rstd, dk)
++        return dq.to(q), dk.to(k), dv.to(v), dg.to(g), db.to(beta), None, dh0, None, None, None, None
++
++
++@torch.compiler.disable
++def chunk_gated_delta_rule(
++    q: torch.Tensor,
++    k: torch.Tensor,
++    v: torch.Tensor,
++    g: torch.Tensor,
++    beta: torch.Tensor,
++    scale: float = None,
++    initial_state: torch.Tensor = None,
++    output_final_state: bool = False,
++    use_qk_l2norm_in_kernel: bool = False,
++    cu_seqlens: Optional[torch.LongTensor] = None,
++    chunk_size: int = 64,
++    head_first: bool = False,
++):
++    # print(f"{__file__=} =============", flush=True)
++    r"""
++    Args:
++        q (torch.Tensor):
++            queries of shape `[B, T, H, K]`.
++        k (torch.Tensor):
++            keys of shape `[B, T, H, K]`.
++        v (torch.Tensor):
++            values of shape `[B, T, H, V]`.
++        g (torch.Tensor):
++            (forget) gating tensor (in log space!) of shape `[B, T, H]`.
++        beta (torch.Tensor):
++            betas of shape `[B, T, H]`.
++        scale (Optional[float]):
++            Scale factor for the RetNet attention scores.
++            If not provided, it will default to `1 / sqrt(K)`. Default: `None`.
++        initial_state (Optional[torch.Tensor]):
++            Initial state of shape `[N, H, K, V]` for `N` input sequences.
++            For equal-length input sequences, `N` equals the batch size `B`.
++            Default: `None`.
++        output_final_state (Optional[bool]):
++            Whether to output the final state of shape `[N, H, K, V]`. Default: `False`.
++        use_qk_l2norm_in_kernel (bool):
++            Whether to apply L2norm to the q/k tensor internally. Default: `False`.
++        cu_seqlens (torch.LongTensor):
++            Cumulative sequence lengths of shape `[N+1]` used for variable-length training,
++            consistent with the FlashAttention API.
++        head_first (Optional[bool]):
++            Whether the inputs are in the head-first format. Default: `False`.
++            This argument has been deprecated.
++
++    Returns:
++        o (torch.Tensor):
++            Outputs of shape `[B, T, H, V]`.
++        final_state (torch.Tensor):
++            Final state of shape `[N, H, K, V]` if `output_final_state=True` else `None`.
++
++    Examples::
++        >>> import torch
++        >>> import torch.nn.functional as F
++        >>> from einops import rearrange
++        >>> from fla.ops.gated_delta_rule import chunk_gated_delta_rule
++        # inputs with equal lengths
++        >>> B, T, H, K, V = 4, 2048, 4, 512, 512
++        >>> q = torch.randn(B, T, H, K, dtype=torch.bfloat16, device='cuda')
++        >>> k = F.normalize(torch.randn(B, T, H, K, dtype=torch.bfloat16, device='cuda'), p=2, dim=-1)
++        >>> v = torch.randn(B, T, H, V, dtype=torch.bfloat16, device='cuda')
++        >>> beta = torch.rand(B, T, H, dtype=torch.bfloat16, device='cuda').sigmoid()
++        >>> g = F.logsigmoid(torch.rand(B, T, H, dtype=torch.bfloat16, device='cuda'))
++        >>> h0 = torch.randn(B, H, K, V, dtype=torch.bfloat16, device='cuda')
++        >>> o, ht = chunk_gated_delta_rule(
++            q, k, v, g, beta,
++            initial_state=h0,
++            output_final_state=True
++        )
++        # for variable-length inputs, the batch size `B` is expected to be 1 and `cu_seqlens` is required
++        >>> q, k, v, beta, g = map(lambda x: rearrange(x, 'b t ... -> 1 (b t) ...'), (q, k, v, beta, g))
++        # for a batch with 4 sequences, `cu_seqlens` with 5 start/end positions are expected
++        >>> cu_seqlens = q.new_tensor([0, 2048, 4096, 6144, 8192], dtype=torch.long)
++        >>> o, ht = chunk_gated_delta_rule(
++            q, k, v, g, beta,
++            initial_state=h0,
++            output_final_state=True,
++            cu_seqlens=cu_seqlens
++        )
++    """
++    if q.dtype != k.dtype or k.dtype != v.dtype:
++        raise ValueError(
++            f"q current type is {q.dtype} , k current type is {k.dtype} ,v current type is {v.dtype} , they should are equal"
++        )
++    if q.dtype == torch.float32:
++        raise ValueError(
++            "ChunkGatedDeltaRuleFunction does not support float32. Please use bfloat16."
++        )
++    if len(beta.shape) != 3:
++        raise ValueError(
++            f"beta current shape len is {len(beta.shape)}, beta must be of shape [B, T, H] if head_first=False, or [B, H, T] otherwise."
++        )
++
++    if head_first:
++        warnings.warn(
++            "head_first is deprecated and will be removed in a future version. "
++            "Please use head_first=False for now instead."
++        )
++    if not head_first and q.shape[1] < q.shape[2]:
++        warnings.warn(
++            f"Input tensor shape suggests potential format mismatch: seq_len ({q.shape[1]}) < num_heads ({q.shape[2]}). "
++            "This may indicate the inputs were passed in head-first format [B, H, T, ...] "
++            "when head_first=False was specified. "
++            "Please verify your input tensor format matches the expected shape [B, T, H, ...]."
++        )
++    if cu_seqlens is not None:
++        if q.shape[0] != 1:
++            raise ValueError(
++                f"The batch size is expected to be 1 rather than {q.shape[0]} when using `cu_seqlens`."
++                f"Please flatten variable-length inputs before processing."
++            )
++        if initial_state is not None and initial_state.shape[0] != len(cu_seqlens) - 1:
++            raise ValueError(
++                f"The number of initial states is expected to be equal to the number of input sequences, "
++                f"i.e., {len(cu_seqlens) - 1} rather than {initial_state.shape[0]}."
++            )
++    if scale is None:
++        scale = k.shape[-1] ** -0.5
++    o, final_state = ChunkGatedDeltaRuleFunction.apply(
++        q,
++        k,
++        v,
++        g,
++        beta,
++        scale,
++        initial_state,
++        output_final_state,
++        cu_seqlens,
++        use_qk_l2norm_in_kernel,
++        chunk_size
++    )
++    return o, final_state
++
++
++####################
++# Torch native gated delta rule
++####################
++def torch_chunk_gated_delta_rule(
++    query,
++    key,
++    value,
++    g,
++    beta,
++    chunk_size=64,
++    initial_state=None,
++    output_final_state=False,
++    use_qk_l2norm_in_kernel=False,
++):
++    # pylint: disable=line-too-long
++    '''
++    Torch-native implementation of chunked gated delta rule for deterministic mode.
++    Need this because FLA is not deterministic.
++    '''
++
++    initial_dtype = query.dtype
++    if use_qk_l2norm_in_kernel:
++        query = l2norm(query, dim=-1, eps=1e-6)
++        key = l2norm(key, dim=-1, eps=1e-6)
++    query, key, value, beta, g = [
++        x.transpose(1, 2).contiguous().to(torch.float32) for x in (query, key, value, beta, g)
++    ]
++
++    batch_size, num_heads, sequence_length, k_head_dim = key.shape
++    v_head_dim = value.shape[-1]
++    pad_size = (chunk_size - sequence_length % chunk_size) % chunk_size
++    query = F.pad(query, (0, 0, 0, pad_size))
++    key = F.pad(key, (0, 0, 0, pad_size))
++    value = F.pad(value, (0, 0, 0, pad_size))
++    beta = F.pad(beta, (0, pad_size))
++    g = F.pad(g, (0, pad_size))
++    total_sequence_length = sequence_length + pad_size
++    scale = 1 / (query.shape[-1] ** 0.5)
++    query = query * scale
++
++    v_beta = value * beta.unsqueeze(-1)
++    k_beta = key * beta.unsqueeze(-1)
++    # reshape to chunks
++    query, key, value, k_beta, v_beta = [
++        x.reshape(x.shape[0], x.shape[1], -1, chunk_size, x.shape[-1])
++        for x in (query, key, value, k_beta, v_beta)
++    ]
++    g = g.reshape(g.shape[0], g.shape[1], -1, chunk_size)
++    mask = torch.triu(
++        torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=query.device), diagonal=0
++    )
++
++    # chunk decay
++    g = g.cumsum(dim=-1)
++    decay_mask = ((g.unsqueeze(-1) - g.unsqueeze(-2)).tril().exp().float()).tril()
++    attn = -((k_beta @ key.transpose(-1, -2)) * decay_mask).masked_fill(mask, 0)
++    for i in range(1, chunk_size):
++        row = attn[..., i, :i].clone()
++        sub = attn[..., :i, :i].clone()
++        attn[..., i, :i] = row + (row.unsqueeze(-1) * sub).sum(-2)
++    attn = attn + torch.eye(chunk_size, dtype=attn.dtype, device=attn.device)
++    value = attn @ v_beta
++    k_cumdecay = attn @ (k_beta * g.exp().unsqueeze(-1))
++    last_recurrent_state = (
++        torch.zeros(batch_size, num_heads, k_head_dim, v_head_dim).to(value)
++        if initial_state is None
++        else initial_state.to(value)
++    )
++    core_attn_out = torch.zeros_like(value)
++    mask = torch.triu(
++        torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=query.device), diagonal=1
++    )
++
++    # for each chunk
++    for i in range(0, total_sequence_length // chunk_size):
++        q_i, k_i, v_i = query[:, :, i], key[:, :, i], value[:, :, i]
++        attn = (q_i @ k_i.transpose(-1, -2) * decay_mask[:, :, i]).masked_fill_(mask, 0)
++        v_prime = (k_cumdecay[:, :, i]) @ last_recurrent_state
++        v_new = v_i - v_prime
++        attn_inter = (q_i * g[:, :, i, :, None].exp()) @ last_recurrent_state
++        core_attn_out[:, :, i] = attn_inter + attn @ v_new
++        last_recurrent_state = (
++            last_recurrent_state * g[:, :, i, -1, None, None].exp()
++            + (k_i * (g[:, :, i, -1, None] - g[:, :, i]).exp()[..., None]).transpose(-1, -2) @ v_new
++        )
++
++    if not output_final_state:
++        last_recurrent_state = None
++    core_attn_out = core_attn_out.reshape(
++        core_attn_out.shape[0], core_attn_out.shape[1], -1, core_attn_out.shape[-1]
++    )
++    core_attn_out = core_attn_out[:, :, :sequence_length]
++    core_attn_out = core_attn_out.transpose(1, 2).contiguous().to(initial_dtype)
++    return core_attn_out, last_recurrent_state
+\ No newline at end of file
+diff --git a/mindspeed/patch_utils.py b/mindspeed/patch_utils.py
+index a489d58c..c3cd6f9f 100644
+--- a/mindspeed/patch_utils.py
++++ b/mindspeed/patch_utils.py
+@@ -1,4 +1,5 @@
+ import importlib
++import inspect
+ import sys
+ import types
+ from typing import List, Dict, Union
+@@ -93,8 +94,12 @@ class Patch:
+ 
+     def remove_patch(self):
+         for key, value in sys.modules.copy().items():
+-            if 'mindspeed' in key:
++            if 'mindspeed' in key or 'torch.classes' == key:
+                 continue
++
++            if inspect.isclass(self.orig_module) and hasattr(value, self.orig_module_name.split('.')[-1]):
++                value = getattr(value, self.orig_module_name.split('.')[-1])
++
+             if self.orig_func_name is not None and hasattr(value, self.orig_func_name) \
+                     and id(getattr(value, self.orig_func_name)) == id(self.final_patch_func):
+                 setattr(value, self.orig_func_name, self.orig_func)
+diff --git a/mindspeed/te/pytorch/attention/dot_product_attention/dot_product_attention.py b/mindspeed/te/pytorch/attention/dot_product_attention/dot_product_attention.py
+index ac4eabe5..44f21ba2 100644
+--- a/mindspeed/te/pytorch/attention/dot_product_attention/dot_product_attention.py
++++ b/mindspeed/te/pytorch/attention/dot_product_attention/dot_product_attention.py
+@@ -1,11 +1,12 @@
+ # Copyright (c) 2025, Huawei Technologies Co., Ltd. All rights reserved.
+-# Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
++# Copyright (c) 2022-2026, NVIDIA CORPORATION. All rights reserved.
+ 
+ import dataclasses
+ import math
+ import os
+ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+ 
++import torch.distributed as dist
+ import torch
+ import torch_npu
+ from megatron.core.packed_seq_params import PackedSeqParams
+@@ -13,7 +14,7 @@ from megatron.core.parallel_state import (
+     get_context_parallel_group,
+     get_context_parallel_global_ranks,
+     get_tensor_model_parallel_group,
+-    get_hierarchical_context_parallel_groups
++    get_hierarchical_context_parallel_groups    
+ )
+ from megatron.core.process_groups_config import ProcessGroupCollection
+ 
+@@ -320,6 +321,8 @@ class DotProductAttention(torch.nn.Module):
+         cu_seqlens_kv_padded: torch.Tensor = None,
+         max_seqlen_q: int = None,
+         max_seqlen_kv: int = None,
++        local_cp_size: int = None,
++        cp_group: dist.ProcessGroup = None,
+         attn_mask_type: Optional[str] = None,
+         window_size: Optional[Tuple[int, int]] = None,
+         checkpoint_core_attention: bool = False,
+@@ -587,14 +590,14 @@ class MindSpeedTEDotProductAttention(DotProductAttention):
+         else:
+             assert hasattr(
+                 pg_collection, "tp"
+-            ), "TEDotProductAttention model_comm_pgs must have tp pg"
++            ), "TEDotProductAttention pg_collection must have tp pg"
+             assert hasattr(
+                 pg_collection, "cp"
+-            ), "TEDotProductAttention model_comm_pgs must have cp pg"
+-            if pg_collection == "a2a+p2p":
++            ), "TEDotProductAttention pg_collection must have cp pg"
++            if cp_comm_type == "a2a+p2p":
+                 assert hasattr(
+                     pg_collection, "hcp"
+-                ), "TEDotProductAttention model_comm_pgs must have hierarchical cp pg"
++                ), "TEDotProductAttention pg_collection must have hierarchical cp pg"
+ 
+         # This check is important as CP config can be disabled while having a valid CP group
+         if self.config.context_parallel_size > 1:
+@@ -659,6 +662,9 @@ class MindSpeedTEDotProductAttention(DotProductAttention):
+         ) and not getattr(self.config, 'is_llava', False):
+             self.config.sparse_mode = 2
+             attention_mask = get_attention_mask(self.config)
++        attention_mask = torch.triu(
++            torch.ones((2048, 2048),
++                       device=query.device, dtype=torch.bool), diagonal=1)
+ 
+         packed_seq_kwargs = (
+             {key: getattr(packed_seq_params, key) for key in self.kept_packed_seq_params}
+diff --git a/mindspeed/te/pytorch/module/layernorm_column_parallel_linear.py b/mindspeed/te/pytorch/module/layernorm_column_parallel_linear.py
+index d04f8a62..416a9da5 100644
+--- a/mindspeed/te/pytorch/module/layernorm_column_parallel_linear.py
++++ b/mindspeed/te/pytorch/module/layernorm_column_parallel_linear.py
+@@ -224,12 +224,20 @@ class MindSpeedTELayerNormColumnParallelLinear(torch.nn.Module):
+                             bias=self.layer_norm_bias,
+                             eps=self.config.layernorm_epsilon
+                             )
+-
++    
++    def _rmsnorm_scale(self, x_norm):
++        """Plain γ*x_norm or TE zero-centered (1+γ)*x_norm."""
++        if getattr(self.config, "layernorm_zero_centered_gamma", False):
++            return x_norm * (1 + self.layer_norm_weight)
++        return x_norm * self.layer_norm_weight
++    
+     def _rmsnorm(self, inp):
+-        if self.config.use_fused_rmsnorm:
++        zero_centered_gamma = getattr(self.config, "layernorm_zero_centered_gamma", False)
++        use_fused = self.config.use_fused_rmsnorm and not zero_centered_gamma
++        if use_fused:
+             return torch_npu.npu_rms_norm(inp, self.layer_norm_weight, epsilon=self.config.layernorm_epsilon)[0]
+-        return (inp * torch.rsqrt(inp.pow(2).mean(-1, keepdim=True) + self.config.layernorm_epsilon)) \
+-                * self.layer_norm_weight
++        x_norm = inp * torch.rsqrt(inp.pow(2).mean(-1, keepdim=True) + self.config.layernorm_epsilon)
++        return self._rmsnorm_scale(x_norm)
+ 
+     def enable_recompute_norm(self, norm_ckpt):
+         self.is_recompute_norm = True

--- a/docker/npu_patch/sgl-kernel-npu-9b.patch
+++ b/docker/npu_patch/sgl-kernel-npu-9b.patch
@@ -1,0 +1,935 @@
+From 8757f1fd40e408ff0823107f198f262e6bf01221 Mon Sep 17 00:00:00 2001
+From: huangxudong <hxd_a@qq.com>
+Date: Mon, 15 Jun 2026 19:20:09 +0800
+Subject: [PATCH] tms adapt colacate
+
+---
+ contrib/torch_memory_saver/csrc/core.cpp      |  56 ++++++-
+ .../torch_memory_saver/csrc/entrypoint.cpp    |  50 ++++--
+ contrib/torch_memory_saver/csrc/utils.h       |  22 +++
+ .../python/torch_memory_saver/entrypoint.py   |  42 +++--
+ .../torch_memory_saver/hooks/mode_preload.py  |  14 +-
+ contrib/torch_memory_saver/test/cuda_graph.py | 152 ++++++++++++++++++
+ .../torch_memory_saver/test/multi_device.py   |   3 -
+ contrib/torch_memory_saver/test/rl_example.py |  39 +++--
+ contrib/torch_memory_saver/test/simple.py     |   3 -
+ .../test/test_disable_releases_pool.py        | 121 ++++++++++++++
+ .../test/training_engine.py                   |  96 +++++++++++
+ 11 files changed, 533 insertions(+), 65 deletions(-)
+ create mode 100644 contrib/torch_memory_saver/test/cuda_graph.py
+ create mode 100644 contrib/torch_memory_saver/test/test_disable_releases_pool.py
+ create mode 100644 contrib/torch_memory_saver/test/training_engine.py
+
+diff --git a/contrib/torch_memory_saver/csrc/core.cpp b/contrib/torch_memory_saver/csrc/core.cpp
+index 581971c..e04bca1 100644
+--- a/contrib/torch_memory_saver/csrc/core.cpp
++++ b/contrib/torch_memory_saver/csrc/core.cpp
+@@ -1,4 +1,5 @@
+ #include "core.h"
++#include "api_forwarder.h"
+ #include "utils.h"
+ 
+ TorchMemorySaver::TorchMemorySaver() {}
+@@ -23,6 +24,15 @@ aclError TorchMemorySaver::malloc(void **ptr, int device, size_t size,
+         *ptr, AllocationMetadata{size, device, allocHandle, tag,
+                                  enable_cpu_backup, nullptr});
+   }
++  if (enable_cpu_backup) {
++    std::cerr << "[TMS-MALLOC] enable_cpu_backup=true"
++              << " ptr=" << *ptr
++              << " size=" << size
++              << " tag=" << tag
++              << " device=" << device
++              << " map_size=" << allocation_metadata_.size()
++              << std::endl;
++  }
+ #ifdef TMS_DEBUG_LOG
+   std::cout << "[torch_memory_saver.cpp] TorchMemorySaver.cuda_malloc "
+             << " ptr=" << ptr << " *ptr=" << *ptr << " size=" << size
+@@ -35,14 +45,43 @@ aclError TorchMemorySaver::free(void *ptr) {
+   AllocationMetadata metadata;
+   {
+     const std::lock_guard<std::mutex> lock(allocator_metadata_mutex_);
+-    SIMPLE_CHECK(allocation_metadata_.count(ptr),
+-                 "Trying to free a pointer not allocated here");
++    if (allocation_metadata_.count(ptr) == 0) {
++      return APIForwarder::call_real_aclrt_free(ptr);
++    }
+     metadata = allocation_metadata_[ptr];
+     allocation_metadata_.erase(ptr);
+   }
+-  int ret = aclrtUnmapMem(ptr);
++
++  if (metadata.enable_cpu_backup) {
++    std::cerr << "[TMS-FREE] enable_cpu_backup=true"
++              << " ptr=" << ptr
++              << " size=" << metadata.size
++              << " tag=" << metadata.tag
++              << " had_cpu_backup=" << (metadata.cpu_backup != nullptr)
++              << " map_size=" << allocation_metadata_.size()
++              << std::endl;
++  }
++
++  static constexpr int32_t kSyncTimeoutMs = 3000;
++  int ret = aclrtSynchronizeDeviceWithTimeout(kSyncTimeoutMs);
++  SIMPLE_CHECK(ret == ACL_SUCCESS, "aclrtSynchronizeDeviceWithTimeout failed.");
++  ret = aclrtUnmapMem(ptr);
++  if (ret != ACL_SUCCESS) { 
++    std::cout << "[TMS-FREE] aclUnmapMem failed"
++              << " ret=" << ret << " ptr=" << ptr <<std::endl;
++  }
++  SIMPLE_CHECK(ret == ACL_SUCCESS, "aclrtUnmapMem failed.");
+   ret = aclrtFreePhysical(metadata.allocHandle);
++  SIMPLE_CHECK(ret == ACL_SUCCESS, "aclrtFreePhysical failed.");
+   ret = aclrtReleaseMemAddress(ptr);
++  SIMPLE_CHECK(ret == ACL_SUCCESS, "aclrtReleaseMemAddress failed.");
++
++  if (nullptr != metadata.cpu_backup) {
++    ret = aclrtFreeHost(metadata.cpu_backup);
++    SIMPLE_CHECK(ret == ACL_SUCCESS, "aclrtFreeHost failed.");
++    metadata.cpu_backup = nullptr;
++  }
++
+ #ifdef TMS_DEBUG_LOG
+   std::cout << "[torch_memory_saver.cpp] TorchMemorySaver.cuda_free "
+             << " ptr=" << ptr << " metadata.size=" << metadata.size
+@@ -73,7 +112,9 @@ void TorchMemorySaver::pause(const std::string &tag) {
+     }
+ 
+     int ret = aclrtUnmapMem(ptr);
++    SIMPLE_CHECK(ret == ACL_SUCCESS, "aclrtUnmapMem failed.");
+     ret = aclrtFreePhysical(metadata.allocHandle);
++    SIMPLE_CHECK(ret == ACL_SUCCESS, "aclrtFreePhysical failed.");
+ 
+ #ifdef TMS_DEBUG_LOG
+     std::cout << "[torch_memory_saver.cpp] TorchMemorySaver.pause"
+@@ -105,6 +146,15 @@ void TorchMemorySaver::resume(const std::string &tag) {
+     aclrtMapMem(ptr, metadata.size, 0, newAllocHandle, 0);
+ 
+     if (metadata.enable_cpu_backup) {
++      if (metadata.cpu_backup == nullptr) {
++        std::cerr << "[TMS-RESUME-FATAL] null cpu_backup"
++                  << " ptr=" << ptr
++                  << " size=" << metadata.size
++                  << " tag=" << metadata.tag
++                  << " device=" << metadata.device
++                  << " map_size=" << allocation_metadata_.size()
++                  << std::endl;
++      }
+       SIMPLE_CHECK(metadata.cpu_backup != nullptr,
+                    "cpu_backup should not be nullptr");
+       // TODO may use cudaMemcpyAsync if needed
+diff --git a/contrib/torch_memory_saver/csrc/entrypoint.cpp b/contrib/torch_memory_saver/csrc/entrypoint.cpp
+index 3f266dc..17ea097 100644
+--- a/contrib/torch_memory_saver/csrc/entrypoint.cpp
++++ b/contrib/torch_memory_saver/csrc/entrypoint.cpp
+@@ -1,14 +1,36 @@
+ #include "api_forwarder.h"
+ #include "core.h"
+ #include "utils.h"
++#include <optional>
+ 
+ // ----------------------------------------------- threadlocal configs
+ // --------------------------------------------------
+ 
+ struct ThreadLocalConfig {
+-  bool is_interesting_region_ = false;
++public:
+   std::string current_tag_ = "default";
+-  bool enable_cpu_backup_ = false;
++
++  bool is_interesting_region() {
++    if (!is_interesting_region_.has_value()) {
++      is_interesting_region_ = get_bool_env_var("TMS_INIT_ENABLE");
++    }
++    return is_interesting_region_.value();
++  }
++
++  void set_interesting_region(bool value) { is_interesting_region_ = value; }
++
++  bool enable_cpu_backup() {
++    if (!enable_cpu_backup_.has_value()) {
++      enable_cpu_backup_ = get_bool_env_var("TMS_INIT_ENABLE_CPU_BACKUP");
++    }
++    return enable_cpu_backup_.value();
++  }
++
++  void set_enable_cpu_backup(bool value) { enable_cpu_backup_ = value; }
++
++private:
++  std::optional<bool> is_interesting_region_;
++  std::optional<bool> enable_cpu_backup_;
+ };
+ static thread_local ThreadLocalConfig thread_local_config;
+ 
+@@ -18,23 +40,17 @@ static thread_local ThreadLocalConfig thread_local_config;
+ #ifdef TMS_HOOK_MODE_PRELOAD
+ aclError aclrtMallocAlign32(void **ptr, size_t size,
+                             aclrtMemMallocPolicy policy) {
+-  if (thread_local_config.is_interesting_region_) {
++  if (thread_local_config.is_interesting_region()) {
+     return TorchMemorySaver::instance().malloc(
+         ptr, CANNUtils::cann_ctx_get_device(), size,
+         thread_local_config.current_tag_,
+-        thread_local_config.enable_cpu_backup_);
++        thread_local_config.enable_cpu_backup());
+   } else {
+     return APIForwarder::call_real_aclrt_malloc_align32(ptr, size, policy);
+   }
+ }
+ 
+-aclError aclrtFree(void *ptr) {
+-  if (thread_local_config.is_interesting_region_) {
+-    return TorchMemorySaver::instance().free(ptr);
+-  } else {
+-    return APIForwarder::call_real_aclrt_free(ptr);
+-  }
+-}
++aclError aclrtFree(void *ptr) { return TorchMemorySaver::instance().free(ptr); }
+ #endif
+ 
+ #ifdef TMS_HOOK_MODE_TORCH
+@@ -45,12 +61,12 @@ void *tms_torch_malloc(ssize_t size, int device, aclrtStream stream) {
+             << " size=" << size << " device=" << device << " stream=" << stream
+             << std::endl;
+ #endif
+-  SIMPLE_CHECK(thread_local_config.is_interesting_region_,
++  SIMPLE_CHECK(thread_local_config.is_interesting_region(),
+                "only support interesting region");
+   void *ptr;
+   TorchMemorySaver::instance().malloc(&ptr, CANNUtils::cann_device_get(device),
+                                       size, thread_local_config.current_tag_,
+-                                      thread_local_config.enable_cpu_backup_);
++                                      thread_local_config.enable_cpu_backup());
+   return ptr;
+ }
+ 
+@@ -60,7 +76,7 @@ void tms_torch_free(void *ptr, ssize_t ssize, int device, aclrtStream stream) {
+             << " ptr=" << ptr << " ssize=" << ssize << " device=" << device
+             << " stream=" << stream << std::endl;
+ #endif
+-  SIMPLE_CHECK(thread_local_config.is_interesting_region_,
++  SIMPLE_CHECK(thread_local_config.is_interesting_region(),
+                "only support interesting region");
+   TorchMemorySaver::instance().free(ptr);
+ }
+@@ -72,11 +88,11 @@ void tms_torch_free(void *ptr, ssize_t ssize, int device, aclrtStream stream) {
+ 
+ extern "C" {
+ void tms_set_interesting_region(bool is_interesting_region) {
+-  thread_local_config.is_interesting_region_ = is_interesting_region;
++  thread_local_config.set_interesting_region(is_interesting_region);
+ }
+ 
+ bool tms_get_interesting_region() {
+-  return thread_local_config.is_interesting_region_;
++  return thread_local_config.is_interesting_region();
+ }
+ 
+ void tms_set_current_tag(const char *tag) {
+@@ -85,7 +101,7 @@ void tms_set_current_tag(const char *tag) {
+ }
+ 
+ void tms_set_enable_cpu_backup(bool enable_cpu_backup) {
+-  thread_local_config.enable_cpu_backup_ = enable_cpu_backup;
++  thread_local_config.set_enable_cpu_backup(enable_cpu_backup);
+ }
+ 
+ void tms_pause(const char *tag) {
+diff --git a/contrib/torch_memory_saver/csrc/utils.h b/contrib/torch_memory_saver/csrc/utils.h
+index fd837e4..980273f 100644
+--- a/contrib/torch_memory_saver/csrc/utils.h
++++ b/contrib/torch_memory_saver/csrc/utils.h
+@@ -47,3 +47,25 @@ static int cann_ctx_get_device() {
+ static int cann_device_get(int device_ordinal) { return device_ordinal; }
+ 
+ } // namespace CANNUtils
++
++inline bool get_bool_env_var(const char *name) {
++  const char *env_cstr = std::getenv(name);
++  if (env_cstr == nullptr) {
++    return false;
++  }
++
++  std::string env_str(env_cstr);
++  if (env_str == "1" || env_str == "true" || env_str == "TRUE" ||
++      env_str == "yes" || env_str == "YES") {
++    return true;
++  }
++  if (env_str == "0" || env_str == "false" || env_str == "FALSE" ||
++      env_str == "no" || env_str == "NO") {
++    return false;
++  }
++
++  std::cerr
++      << "[torch_memory_saver.cpp] Unsupported environment variable value "
++      << " name=" << name << " value=" << env_str << std::endl;
++  return false;
++}
+diff --git a/contrib/torch_memory_saver/python/torch_memory_saver/entrypoint.py b/contrib/torch_memory_saver/python/torch_memory_saver/entrypoint.py
+index 5281340..cc69733 100644
+--- a/contrib/torch_memory_saver/python/torch_memory_saver/entrypoint.py
++++ b/contrib/torch_memory_saver/python/torch_memory_saver/entrypoint.py
+@@ -5,6 +5,7 @@ from contextlib import contextmanager
+ from typing import Optional
+ 
+ import torch
++import torch_npu
+ 
+ from .binary_wrapper import BinaryWrapper
+ from .hooks.base import HookMode, HookUtilBase
+@@ -50,15 +51,18 @@ class TorchMemorySaver:
+ 
+     @contextmanager
+     def disable(self):
++        self._ensure_initialized()
+         with self._impl.disable():
+             yield
+ 
+     def pause(self, tag: Optional[str] = None):
+         """Pause memory for specific tag or all memory if tag is None"""
++        self._ensure_initialized()
+         self._impl.pause(tag=tag)
+ 
+     def resume(self, tag: Optional[str] = None):
+         """Resume memory for specific tag or all memory if tag is None"""
++        self._ensure_initialized()
+         self._impl.resume(tag=tag)
+ 
+     # for compatibility
+@@ -85,7 +89,9 @@ class TorchMemorySaver:
+ 
+ 
+ class _TorchMemorySaverImpl:
+-    def __init__(self, hook_mode: HookMode = "torch"):
++    def __init__(self, hook_mode: HookMode = None):
++        if hook_mode is None:
++            hook_mode = os.environ.get("TMS_HOOK_MODE", "torch")
+         self._hook_mode = hook_mode
+         self._hook_util = HookUtilBase.create(hook_mode=hook_mode)
+         self._binary_wrapper = BinaryWrapper(
+@@ -134,17 +140,35 @@ class _TorchMemorySaverImpl:
+             )
+ 
+     @contextmanager
+-    def disable(self):
+-        old_is_interesting_region = (
+-            self._binary_wrapper.cdll.tms_get_interesting_region()
+-        )
++    def disable(self, dispose_mem_pool_after_use: bool = True):
++        if not dispose_mem_pool_after_use:
++            raise ValueError("Only dispose_mem_pool_after_use=True is supported now")
++        if not self._binary_wrapper.cdll.tms_get_interesting_region():
++            raise RuntimeError("disable() should be called only when tms is active")
++
+         self._binary_wrapper.cdll.tms_set_interesting_region(False)
+         try:
+-            yield
++            # Affected by the memory allocation mechanism of torch_npu, a new mempool must be adopted.
++            # Otherwise, paused virtual addresses may be reused, causing memory conflicts and trigger errors.
++            pool = torch.npu.MemPool()
++            with torch.npu.use_mem_pool(pool):
++                yield
++
++            torch.npu.synchronize()
++            # _npu_releasePool only marks the pool's blocks as reclaimable in the
++            # caching allocator; the device memory is not handed back to the driver
++            # until empty_cache() runs. We empty_cache() here (while tms is active,
++            # i.e. before re-entering the interesting region) so that the pool's
++            # buffers are released immediately instead of leaking into the next
++            # sleep/rollout cycle. Calling empty_cache() in the active state is
++            # safe because tms-paused virtual addresses are not visible to torch's
++            # caching allocator (their backing physical memory was already freed
++            # via aclrtFreePhysical in pause()).
++            torch_npu._C._npu_releasePool(torch.npu.current_device(), pool.id)
++            del pool
++            torch.npu.empty_cache()
+         finally:
+-            self._binary_wrapper.cdll.tms_set_interesting_region(
+-                old_is_interesting_region
+-            )
++            self._binary_wrapper.cdll.tms_set_interesting_region(True)
+ 
+     def pause(self, tag: Optional[str]):
+         tag_bytes = tag.encode("utf-8") if tag else None
+diff --git a/contrib/torch_memory_saver/python/torch_memory_saver/hooks/mode_preload.py b/contrib/torch_memory_saver/python/torch_memory_saver/hooks/mode_preload.py
+index 2526da3..e4f3135 100644
+--- a/contrib/torch_memory_saver/python/torch_memory_saver/hooks/mode_preload.py
++++ b/contrib/torch_memory_saver/python/torch_memory_saver/hooks/mode_preload.py
+@@ -24,17 +24,11 @@ class HookUtilModePreload(HookUtilBase):
+ @contextmanager
+ def configure_subprocess():
+     """Configure environment variables for subprocesses. Only needed for hook_mode=preload."""
+-    # Currently, torch_memory_saver does not support preload for npu, therefore LD_PRELOAD interception is not implemented.
+-    if hasattr(torch, "npu") and torch.npu.is_available():
++    with _change_env(
++        "LD_PRELOAD",
++        str(get_binary_path_from_package("torch_memory_saver_hook_mode_preload")),
++    ):
+         yield
+-        return
+-
+-    else:
+-        with _change_env(
+-            "LD_PRELOAD",
+-            str(get_binary_path_from_package("torch_memory_saver_hook_mode_preload")),
+-        ):
+-            yield
+ 
+ 
+ @contextmanager
+diff --git a/contrib/torch_memory_saver/test/cuda_graph.py b/contrib/torch_memory_saver/test/cuda_graph.py
+new file mode 100644
+index 0000000..9067683
+--- /dev/null
++++ b/contrib/torch_memory_saver/test/cuda_graph.py
+@@ -0,0 +1,152 @@
++import logging
++import os
++import sys
++import time
++from typing import Callable
++
++import torch
++from torch_memory_saver import torch_memory_saver
++from torch_memory_saver.testing_utils import get_and_print_npu_memory
++
++logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)
++
++dummy_tensor_size = (
++    5,
++    100_000_000,
++)
++cuda_graph_intermediate_tensor_size = (1_000_000_000,)
++
++
++def _ptr(x):
++    assert isinstance(x, torch.Tensor)
++    return hex(x.data_ptr())
++
++
++class KVCache:
++    def __init__(self):
++        self.create_buffers(1)
++
++    def create_buffers(self, value):
++        with torch_memory_saver.region(tag="kv_cache"):
++            # or model weights, etc
++            self.kv_buffer = torch.full(
++                dummy_tensor_size, value, dtype=torch.float32, device="npu"
++            )
++        print(f"create_buffers {_ptr(self.kv_buffer)=}")
++
++    def clear_buffers(self):
++        del self.kv_buffer
++
++    def execute(self, arg: torch.Tensor) -> torch.Tensor:
++        # print(f'KVCache.execute {arg=} {self.kv_buffer=}')
++        ans_value = (arg + self.kv_buffer.mean(dim=1)).mean()
++        big_intermediate_tensor = (
++            torch.ones(cuda_graph_intermediate_tensor_size, device="npu") * ans_value
++        ).mean()
++        return big_intermediate_tensor
++
++
++def create_cuda_graph(fn: Callable, hook_mode):
++    # warmup
++    s = torch.npu.Stream()
++    s.wait_stream(torch.npu.current_stream())
++    with torch.npu.stream(s):
++        print("with torch.npu.stream(s) execute fn")
++        fn()
++    torch.npu.current_stream().wait_stream(s)
++
++    # capture
++    g = torch.npu.NPUGraph()
++    ctx = (
++        torch_memory_saver.cuda_graph(g, tag="graph")
++        if hook_mode == "preload"
++        else torch.npu.graph(g)
++    )
++    with ctx:
++        print("with torch.npu.graph(g) execute fn")
++        fn()
++
++    return g
++
++
++def run(hook_mode: str):
++    torch_memory_saver.hook_mode = hook_mode
++    logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)
++
++    cache = KVCache()
++    static_input = torch.zeros((5,), dtype=torch.float32, device="npu")
++    static_output = torch.zeros((5,), dtype=torch.float32, device="npu")
++    print(f"{_ptr(static_input)=} {_ptr(static_output)=}")
++
++    def fn():
++        nonlocal static_output
++        static_output = cache.execute(static_input)
++
++    g = create_cuda_graph(fn, hook_mode=hook_mode)
++
++    print("replay #1")
++    static_input[...] = 100
++    g.replay()
++    print(f"{static_output=}")
++    assert static_output == 101, f"{static_output=}"
++
++    print("torch.npu.empty_cache()")
++    torch.npu.empty_cache()
++
++    print("sleep...")
++    time.sleep(1)
++
++    mem_before_pause = get_and_print_npu_memory("Before pause")
++
++    print('call memory_saver.pause("kv_cache")')
++    torch_memory_saver.pause("kv_cache")
++    print("sleep...")
++    time.sleep(1)
++
++    mem_after_pause_kv_cache = get_and_print_npu_memory("After pause kv_cache")
++    assert mem_before_pause - mem_after_pause_kv_cache > 400_000_000
++
++    if hook_mode == "preload":
++        print('call memory_saver.pause("graph")')
++        torch_memory_saver.pause("graph")
++        print("sleep...")
++        time.sleep(1)
++
++        mem_after_pause_graph = get_and_print_npu_memory("After pause graph")
++        assert mem_after_pause_kv_cache - mem_after_pause_graph > 3_000_000_000
++
++    print("when kv cache is released, we can allocate *other* big tensors")
++    other_big_tensor = torch.zeros((2500_000_000,), dtype=torch.uint8, device="npu")
++    print("sleep...")
++    time.sleep(1)
++    print(f"{other_big_tensor=}")
++    del other_big_tensor
++    torch.npu.empty_cache()
++    print("sleep...")
++    time.sleep(1)
++
++    if hook_mode == "preload":
++        print('call memory_saver.resume("graph")')
++        torch_memory_saver.resume("graph")
++    print('call memory_saver.resume("kv_cache")')
++    torch_memory_saver.resume("kv_cache")
++
++    dummy = torch.zeros((3,), device="npu")
++    print(f"{_ptr(dummy)=}")
++
++    cache.kv_buffer[...] = 2
++
++    print("replay #2")
++    static_input[...] = 200
++    g.replay()
++    print(f"{static_output=}")
++    assert static_output == 202, f"{static_output=}"
++
++    print("sleep...")
++    time.sleep(1)
++
++    print(f"{dummy=}")
++
++
++if __name__ == "__main__":
++    run(hook_mode=sys.argv[1])
+diff --git a/contrib/torch_memory_saver/test/multi_device.py b/contrib/torch_memory_saver/test/multi_device.py
+index 7830bad..3ebda87 100644
+--- a/contrib/torch_memory_saver/test/multi_device.py
++++ b/contrib/torch_memory_saver/test/multi_device.py
+@@ -17,17 +17,14 @@ def run(hook_mode: str):
+ 
+     with torch_memory_saver.region():
+         dev0_a = torch.full((100_000_000,), 10, dtype=torch.uint8, device="npu:0")
+-    torch.npu.synchronize()
+     checker.check_and_update("alloc dev0_a", min_delta=(80_000_000, 0))
+ 
+     with torch_memory_saver.region():
+         dev1_a = torch.full((100_000_000,), 10, dtype=torch.uint8, device="npu")
+-    torch.npu.synchronize()
+     checker.check_and_update("alloc dev1_a", min_delta=(0, 80_000_000))
+ 
+     with torch_memory_saver.region():
+         dev1_b = torch.full((100_000_000,), 10, dtype=torch.uint8, device="npu:1")
+-    torch.npu.synchronize()
+     checker.check_and_update("alloc dev1_b", min_delta=(0, 80_000_000))
+ 
+     torch_memory_saver.pause()
+diff --git a/contrib/torch_memory_saver/test/rl_example.py b/contrib/torch_memory_saver/test/rl_example.py
+index f93922f..ff885a6 100644
+--- a/contrib/torch_memory_saver/test/rl_example.py
++++ b/contrib/torch_memory_saver/test/rl_example.py
+@@ -3,7 +3,7 @@ This example demonstrates the core functionalities of torch_memory_saver, and th
+ as a short tutorial for readers who want to understand the library. It validates how virtual addresses
+ remain unchanged while physical memory is released during pause and reallocated upon resume, illustrating the
+ mechanisms of pausing and resuming memory regions, the implications for data consistency, and the preservation
+-of functional integrity for tensor operations and CUDA graphs.
++of functional integrity for tensor operations and NPU graphs.
+ """
+ 
+ import logging
+@@ -29,7 +29,7 @@ def _ptr(x):
+     Get the virtual address of a tensor.
+ 
+     Virtual Address is the address that the process sees, not the actual physical memory address.
+-    It needs to be mapped to actual NPU physical memory through the CUDA driver.
++    It needs to be mapped to actual NPU physical memory through the CANN driver.
+     In torch_memory_saver, this virtual address remains unchanged during pause/resume operations.
+     """
+     assert isinstance(x, torch.Tensor)
+@@ -108,15 +108,14 @@ class KVCache:
+         return (arg + self.kv_buffer.mean(dim=1)).mean()
+ 
+ 
+-# https://pytorch.org/blog/accelerating-pytorch-with-cuda-graphs/
+-def create_cuda_graph(fn: Callable):
++def create_npu_graph(fn: Callable):
+     """
+-    Create CUDA graph for validating the impact of memory management on CUDA graphs.
++    Create NPU graph for validating the impact of memory management on NPU graphs.
+ 
+     Validation objectives:
+-    1. Whether CUDA graphs can still work normally after pause/resume.
+-    2. The importance of virtual address remaining unchanged for CUDA graphs.
+-    3. CUDA graphs can still execute correctly even when physical memory is reallocated.
++    1. Whether NPU graphs can still work normally after pause/resume.
++    2. The importance of virtual address remaining unchanged for NPU graphs.
++    3. NPU graphs can still execute correctly even when physical memory is reallocated.
+     """
+     s = torch.npu.Stream()
+     s.wait_stream(torch.npu.current_stream())
+@@ -145,7 +144,7 @@ def run(hook_mode: str):
+        - Disconnect the mapping from virtual address to physical memory.
+        - Release physical memory back to NPU memory pool.
+        - Keep virtual address unchanged.
+-       - Accessing paused tensors will cause CUDA errors.
++       - Accessing paused tensors will cause CANN errors.
+ 
+     3. Resume mechanism.
+        - Allocate new physical memory from NPU memory pool.
+@@ -160,7 +159,7 @@ def run(hook_mode: str):
+ 
+     5. Functional integrity.
+        - Tensor operations can still work normally even when physical memory is reallocated.
+-       - CUDA graphs can still execute correctly (because virtual address remains unchanged).
++       - NPU graphs can still execute correctly (because virtual address remains unchanged).
+        - Selective pause/resume functionality works normally.
+     """
+ 
+@@ -175,28 +174,28 @@ def run(hook_mode: str):
+         f"Original addresses - KV cache: {original_kv_cache_ptr}, Model weights: {original_model_weights_ptr}"
+     )
+ 
+-    # Create static input/output tensors for CUDA graphs
++    # Create static input/output tensors for NPU graphs
+     # These tensors are not managed by torch_memory_saver, addresses will change normally
+     static_input = torch.zeros((20_480,), dtype=torch.float32, device="npu")
+     static_output = torch.zeros((), dtype=torch.float32, device="npu")
+ 
+     def fn():
+-        """Function executed in CUDA graph: combine KV cache and model computation"""
++        """Function executed in NPU graph: combine KV cache and model computation"""
+         nonlocal static_output
+         kv_output = cache.execute(static_input[:5])
+         model_output = model.forward(static_input)
+         static_output = kv_output + model_output
+ 
+-    # Create CUDA graph
+-    g = create_cuda_graph(fn)
++    # Create NPU graph
++    g = create_npu_graph(fn)
+ 
+-    # First execution of CUDA graph
++    # First execution of NPU graph
+     static_input[...] = 100
+     g.replay()
+     print(f"First execution result: {static_output.item()}")
+     if static_output != 2048101:
+         raise ValueError(f"Expected 2048101, got {static_output}")
+-    print("✓ CUDA graph first execution passed!")
++    print("✓ NPU graph first execution passed!")
+ 
+     time.sleep(1)
+ 
+@@ -244,15 +243,15 @@ def run(hook_mode: str):
+     with torch.no_grad():
+         model.linear.weight[...] = 2
+ 
+-    # Second execution of CUDA graph, validate functional integrity
+-    # Even when physical memory is reallocated, CUDA graph can still work normally
+-    # This is because virtual address remains unchanged, addresses recorded in CUDA graph are still valid
++    # Second execution of NPU graph, validate functional integrity
++    # Even when physical memory is reallocated, NPU graph can still work normally
++    # This is because virtual address remains unchanged, addresses recorded in NPU graph are still valid
+     static_input[...] = 200
+     g.replay()
+     print(f"Second execution result: {static_output.item()}")
+     if static_output != 8192202:
+         raise ValueError(f"Expected 8192202, got {static_output}")
+-    print("✓ CUDA graph second execution passed!")
++    print("✓ NPU graph second execution passed!")
+ 
+     time.sleep(1)
+ 
+diff --git a/contrib/torch_memory_saver/test/simple.py b/contrib/torch_memory_saver/test/simple.py
+index 90d52e9..fafdf47 100644
+--- a/contrib/torch_memory_saver/test/simple.py
++++ b/contrib/torch_memory_saver/test/simple.py
+@@ -15,7 +15,6 @@ def run(hook_mode: str):
+         pauseable_tensor = torch.full(
+             (1_000_000_000,), 100, dtype=torch.uint8, device="npu"
+         )
+-    torch.npu.synchronize()
+     original_address = pauseable_tensor.data_ptr()
+     print(f"Pauseable tensor virtual address: 0x{original_address:x}")
+     print(f"{normal_tensor=} {pauseable_tensor=}")
+@@ -44,7 +43,6 @@ def run(hook_mode: str):
+ 
+     print("sleep...")
+     time.sleep(1)
+-    torch.npu.synchronize()
+     print(f"{normal_tensor=} {pauseable_tensor=}")
+ 
+     get_and_print_npu_memory("Before empty cache")
+@@ -56,7 +54,6 @@ def run(hook_mode: str):
+     get_and_print_npu_memory("Before empty cache (tensor deleted)")
+     torch.npu.empty_cache()
+     get_and_print_npu_memory("After empty cache (tensor deleted)")
+-    torch.npu.synchronize()
+ 
+ 
+ if __name__ == "__main__":
+diff --git a/contrib/torch_memory_saver/test/test_disable_releases_pool.py b/contrib/torch_memory_saver/test/test_disable_releases_pool.py
+new file mode 100644
+index 0000000..c7d760d
+--- /dev/null
++++ b/contrib/torch_memory_saver/test/test_disable_releases_pool.py
+@@ -0,0 +1,121 @@
++"""Verify the fix: tms.disable() context now releases its MemPool back to the
++driver on exit, instead of leaking it until the next wake_up + empty_cache.
++
++Mirrors the behavior of the GPU version of torch_memory_saver. Before the fix,
++NPU's behavior was inconsistent (memory allocated inside disable() stayed
++reserved until empty_cache() was called externally).
++"""
++
++import logging
++import os
++import sys
++
++import torch
++from torch_memory_saver import torch_memory_saver
++from torch_memory_saver.testing_utils import get_and_print_npu_memory
++
++
++def run(hook_mode: str):
++    assert os.environ["TMS_INIT_ENABLE"] == "1"
++    assert os.environ["TMS_INIT_ENABLE_CPU_BACKUP"] == "1"
++    assert hook_mode == "preload"
++
++    torch_memory_saver.hook_mode = hook_mode
++    logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)
++
++    # Touch NPU once to materialise the runtime / default streams so they don't
++    # skew the baseline measurement.
++    _ = torch.full((1_000_000,), 42, dtype=torch.uint8, device="npu")
++    mem_initial = get_and_print_npu_memory("Init (baseline)")
++
++    # Simulate the Relax weight-update pattern: model weights live in the
++    # tms-managed region, then we want to do a big all-gather inside disable().
++    # Keep allocations modest so the test fits even on a busy device.
++    MODEL_BYTES = 128 * 1024 ** 2  # 128 MiB per weight
++    TEMP_BYTES = 512 * 1024 ** 2   # 512 MiB temp buffer in disable()
++
++    model_weights = [
++        torch.full((MODEL_BYTES,), 42, dtype=torch.uint8, device="npu")
++        for _ in range(2)  # ~256 MiB of "model weights" (in tms region)
++    ]
++    # Touch each weight (no temporary allocations) so kernels are scheduled.
++    for w in model_weights:
++        _ = w[:1024].sum().item()
++    torch.npu.synchronize()
++    mem_after_model = get_and_print_npu_memory("After model alloc (in tms region)")
++    assert mem_after_model > mem_initial + MODEL_BYTES, (
++        f"model alloc did not raise memory: {mem_after_model/1024**3:.2f} GB"
++    )
++
++    # Sleep: move the model to CPU
++    torch_memory_saver.pause()
++    mem_after_pause = get_and_print_npu_memory("After tms.pause()")
++    # paused → only the baseline + caching allocator metadata remains
++    assert mem_after_pause < mem_initial + 200 * 1024 ** 2, (
++        f"pause did not release physical memory: {mem_after_pause/1024**3:.2f} GB"
++    )
++
++    # Mimic the "update_weights inside disable()" flow used by Relax:
++    # allocate a big temporary buffer (like all_gather output), then release it.
++    with torch_memory_saver.disable():
++        mem_in_disable_start = get_and_print_npu_memory(
++            "Inside disable() before alloc"
++        )
++        # Big temporary tensor — this is the analogue of the all_gather buffer
++        # that used to leak ~8 GiB in the Relax 9B run.
++        big_buf = torch.full(
++            (TEMP_BYTES,), 99, dtype=torch.uint8, device="npu"
++        )
++        # Touch a small slice to make sure it's really mapped (avoid summing
++        # the whole 2 GiB which would be slow and could overflow).
++        out = big_buf[:1024].sum().item()
++        assert out == 99 * 1024, f"big_buf checksum mismatch: {out}"
++
++        mem_in_disable_peak = get_and_print_npu_memory(
++            "Inside disable() at peak (512 MiB temp)"
++        )
++        assert mem_in_disable_peak > mem_in_disable_start + TEMP_BYTES * 0.9, (
++            f"temp buf did not raise memory: peak={mem_in_disable_peak/1024**3:.2f} GB "
++            f"vs start={mem_in_disable_start/1024**3:.2f} GB"
++        )
++
++        # Drop the reference -- but in the OLD behavior the MemPool still held
++        # the 2 GiB until empty_cache() was called externally.
++        del big_buf
++
++    # ★★★ Key assertion: after exiting disable(), the 4 GiB should be released. ★★★
++    mem_after_exit_disable = get_and_print_npu_memory("After exiting disable()")
++
++    expected_max = mem_after_pause + 200 * 1024 ** 2  # allow 200 MiB slack
++    leaked = mem_after_exit_disable - mem_after_pause
++    print(
++        f"\nLeak check: mem_after_exit_disable={mem_after_exit_disable/1024**3:.2f} GB "
++        f"vs mem_after_pause={mem_after_pause/1024**3:.2f} GB "
++        f"(diff={leaked/1024**3:.2f} GB, allowed slack=0.20 GB)"
++    )
++    assert mem_after_exit_disable <= expected_max, (
++        f"FAIL: disable() leaked memory!\n"
++        f"  before disable (paused): {mem_after_pause / 1024**3:.2f} GB\n"
++        f"  after exiting disable:   {mem_after_exit_disable / 1024**3:.2f} GB\n"
++        f"  leaked:                  {leaked / 1024**3:.2f} GB\n"
++        f"  expected leak:           < 0.20 GB"
++    )
++    print("✅ PASS: disable() correctly released its MemPool on exit")
++
++    # And resume should still work normally
++    torch_memory_saver.resume()
++    mem_after_resume = get_and_print_npu_memory("After tms.resume()")
++    assert mem_after_resume > mem_after_exit_disable + MODEL_BYTES * 0.9, (
++        f"resume did not restore model weights: "
++        f"{mem_after_resume/1024**3:.2f} GB vs {mem_after_exit_disable/1024**3:.2f} GB"
++    )
++
++    # Sanity: model weights are still intact
++    for i, w in enumerate(model_weights):
++        s = w[:1024].sum().item()
++        assert s == 42 * 1024, f"weight {i} corrupted after disable+resume: {s}"
++    print("✅ PASS: model weights survived disable() round-trip")
++
++
++if __name__ == "__main__":
++    run(hook_mode=sys.argv[1])
+diff --git a/contrib/torch_memory_saver/test/training_engine.py b/contrib/torch_memory_saver/test/training_engine.py
+new file mode 100644
+index 0000000..d3eaa00
+--- /dev/null
++++ b/contrib/torch_memory_saver/test/training_engine.py
+@@ -0,0 +1,96 @@
++import logging
++import os
++import sys
++from functools import reduce
++from typing import List
++
++import torch
++from torch_memory_saver import torch_memory_saver
++from torch_memory_saver.testing_utils import get_and_print_npu_memory
++
++
++def run(hook_mode: str):
++    assert os.environ["TMS_INIT_ENABLE"] == "1"
++    assert os.environ["TMS_INIT_ENABLE_CPU_BACKUP"] == "1"
++    assert hook_mode == "preload"
++
++    torch_memory_saver.hook_mode = hook_mode
++    logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)
++
++    initial_tensor = torch.full((1_000_000,), 42, dtype=torch.uint8, device="npu")
++    mem_initial = get_and_print_npu_memory("Init")
++
++    model_weights = [
++        torch.full((size,), 42, dtype=torch.uint8, device="npu")
++        for size in [1024**3, 1024**2, 1024**1, 42]
++    ]
++
++    _execute_forward_pass_and_assert(model_weights)
++    mem_after_forward_pass = get_and_print_npu_memory("After forward pass")
++    assert mem_after_forward_pass > mem_initial + 5 * 1024**3
++
++    torch_memory_saver.pause()
++    mem_after_pause = get_and_print_npu_memory("After pause")
++    assert mem_after_pause < mem_initial + 200 * 1024**2
++
++    with torch_memory_saver.disable():
++        mem_after_disable = get_and_print_npu_memory("After disable")
++        assert mem_after_disable == mem_after_pause
++
++        # Can still execute code in disabled region
++        tensor_in_disabled_region = torch.full(
++            (1024**3,), 53, dtype=torch.uint8, device="npu"
++        )
++        out = tensor_in_disabled_region.float().mean().item()
++        assert out == 53, f"{out=}"
++
++        mem_after_exec_in_disable = get_and_print_npu_memory("After exec in disable")
++        assert mem_after_exec_in_disable > mem_after_disable + 4 * 1024**3
++
++        del tensor_in_disabled_region
++    torch_memory_saver.resume()
++    torch.npu.empty_cache()
++    torch_memory_saver.pause()
++    """
++    Currently, the behavior in this scenario is inconsistent with the GPU version of                                        torch_memory_saver. The NPU memory allocated within the disable() context is not                                        released immediately; it will only be freed when torch.npu.empty_cache() is invoked.
++    Additionally, since empty_cache() takes effect for all memory pools, it is not                                          recommended to invoke it in the paused state, as this may corrupt the address
++    spaces that have already been paused.
++
++    Expected (GPU): mem_after_exit_disable <= mem_after_pause + 10 * 1024 ** 2
++    NPU Current: mem_after_exit_disable == mem_after_exec_in_disable
++    """
++    mem_after_exit_disable = get_and_print_npu_memory("After exiting disable")
++    assert mem_after_exit_disable == mem_after_exec_in_disable
++
++    torch_memory_saver.resume()
++    mem_after_resume = get_and_print_npu_memory("After resume")
++    delta_expect = mem_after_forward_pass - mem_after_pause
++    delta_actual = mem_after_resume - mem_after_exit_disable
++    assert delta_expect - 50 * 1024**2 < delta_actual < delta_expect + 50 * 1024**2
++
++    _execute_forward_pass_and_assert(model_weights)
++    mem_after_second_forward_pass = get_and_print_npu_memory(
++        "After second forward pass"
++    )
++    assert (
++        mem_after_resume - 1024**2
++        < mem_after_second_forward_pass
++        < mem_after_resume + 1024**2
++    )
++
++    del initial_tensor
++
++
++def _execute_forward_pass_and_assert(weights: List[torch.Tensor]):
++    # simulate large activations during forward pass
++    ones = torch.ones((1024**3,), dtype=torch.float32, device="npu")
++    sum_avg_weights = reduce(
++        lambda a, b: (a + b) / 2, [w.float().mean() for w in weights]
++    )
++    outs = ones * sum_avg_weights
++    out = outs.mean().item()
++    assert out == 42, f"{out=}"
++
++
++if __name__ == "__main__":
++    run(hook_mode=sys.argv[1])
+-- 
+2.34.1

--- a/relax/backends/megatron/model_provider.py
+++ b/relax/backends/megatron/model_provider.py
@@ -322,6 +322,8 @@ def get_model_provider_func(
             provider.num_layers_in_first_pipeline_stage = args.decoder_first_pipeline_num_layers
         if getattr(args, "decoder_last_pipeline_num_layers", None) is not None:
             provider.num_layers_in_last_pipeline_stage = args.decoder_last_pipeline_num_layers
+        if hasattr(args, "gradient_accumulation_fusion"):
+            provider.gradient_accumulation_fusion = args.gradient_accumulation_fusion
 
         if is_npu_available:
             for key, value in vars(args).items():

--- a/scripts/entrypoint/local-npu.sh
+++ b/scripts/entrypoint/local-npu.sh
@@ -57,9 +57,9 @@ set -x
 unset MASTER_ADDR 2>/dev/null || true
 export PYTHONUNBUFFERED=1
 export CUDA_DEVICE_MAX_CONNECTIONS=1
-export MEGATRON=${MEGATRON:-/root/Megatron-LM/}
-export MEGATRON_BRIDGE_SRC=${MEGATRON_BRIDGE_SRC:-/root/Megatron-Bridge/src/}
-export MINDSPEED=${MINDSPEED:-/root/MindSpeed/}
+export MEGATRON=${MEGATRON:-/workspace/Megatron-LM/}
+export MEGATRON_BRIDGE_SRC=${MEGATRON_BRIDGE_SRC:-/workspace/Megatron-Bridge/src/}
+export MINDSPEED=${MINDSPEED:-/workspace/MindSpeed/}
 export RELAX=${RELAX:-${_LOCAL_SH_DIR}/../../}
 export PYTHONPATH=${RELAX}:${MEGATRON_BRIDGE_SRC}:${MINDSPEED}:$MEGATRON:$RELAX:${PYTHONPATH:-}
 export MODEL_CONFIG_DIR="${_LOCAL_SH_DIR}/../models"

--- a/scripts/entrypoint/ray-job-npu.sh
+++ b/scripts/entrypoint/ray-job-npu.sh
@@ -94,9 +94,9 @@ export MASTER_ADDR=$(ray list nodes --format json | jq -r '
 
 export PYTHONUNBUFFERED=1
 export CUDA_DEVICE_MAX_CONNECTIONS=1
-export MEGATRON=${MEGATRON:-/root/Megatron-LM/}
-export MEGATRON_BRIDGE_SRC=${MEGATRON_BRIDGE_SRC:-/root/Megatron-Bridge/src/}
-export MINDSPEED=${MINDSPEED:-/root/MindSpeed/}
+export MEGATRON=${MEGATRON:-/workspace/Megatron-LM/}
+export MEGATRON_BRIDGE_SRC=${MEGATRON_BRIDGE_SRC:-/workspace/Megatron-Bridge/src/}
+export MINDSPEED=${MINDSPEED:-/workspace/MindSpeed/}
 export RELAX=${RELAX:-${DIR}/../../}
 export PYTHONPATH=${RELAX}:${MEGATRON_BRIDGE_SRC}:${MINDSPEED}:$MEGATRON:$RELAX:${PYTHONPATH:-}
 export MODEL_CONFIG_DIR="${DIR}/../models"

--- a/scripts/training/text/run-qwen35-9B-8xgpu-async-npu.sh
+++ b/scripts/training/text/run-qwen35-9B-8xgpu-async-npu.sh
@@ -1,0 +1,176 @@
+#!/bin/bash
+
+# Copyright (c) 2026 Relax Authors. All Rights Reserved.
+#
+# Qwen3.5-9B 8xNPU (1-node) fully async training script for DAPO math dataset.
+#
+# Usage:
+#   bash scripts/training/text/run-qwen35-9B-8xgpu-async-npu.sh
+
+set -ex
+set -o pipefail
+export SGLANG_SET_CPU_AFFINITY=1
+export STREAMS_PER_DEVICE=32
+export HCCL_BUFFSIZE=1536
+export HCCL_OP_EXPANSION_MODE=AIV
+export PYTHONPATH=/workspace/Megatron-Bridge/src/:/workspace/Megatron-LM/:/workspace/MindSpeed/:$PYTHONPATH
+now=$(date "+%Y-%m-%d-%H:%M:%S")
+echo "当前时间: $now"
+HOST_IP=$(hostname -I | awk '{print $1}')
+export ASCEND_RT_VISIBLE_DEVICES="0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15"
+export HCCL_NPU_SOCKET_PORT_RANGE="62000-62050"
+export HCCL_HOST_SOCKET_PORT_RANGE="62100-62200"
+export PYTORCH_NPU_ALLOC_CONF="expandable_segments:True"
+
+export TQ_CONTROLLER_GET_METADATA_TIMEOUT=20
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+# Auto-source local environment when not launched via an external entrypoint
+if [ -z "${RELAX_ENTRYPOINT_MODE:-}" ]; then
+    source "${SCRIPT_DIR}/../../entrypoint/local-npu.sh"
+fi
+source "${MODEL_CONFIG_DIR}/qwen35-9B.sh"
+# source "${MODEL_CONFIG_DIR}/qwen3-vl-4B.sh"
+
+PROJECT_NAME="${PROJECT_NAME:=Relax/dev/dapo-math}"
+EXP_DIR="${EXP_DIR:-${SCRIPT_DIR}/../../../../exps}"
+NUM_ROLLOUT="${NUM_ROLLOUT:=1000}"
+
+CKPT_ARGS=(
+   --hf-checkpoint ${EXP_DIR}/Qwen3.5-9B
+   --ref-load ${EXP_DIR}/Qwen3.5-9B
+   --megatron-to-hf-mode bridge
+
+   #--load ${EXP_DIR}/Qwen3-9B_mcore_8xgpu/
+   --save ${EXP_DIR}/Qwen35-9B_mcore_8xgpu_617/
+   --save-interval 100
+   --max-actor-ckpt-to-keep 1
+)
+
+PROMPT_SET=${EXP_DIR}/dapo-math-17k/dapo-math-17k.jsonl
+
+ROLLOUT_ARGS=(
+   --prompt-data ${PROMPT_SET}
+   --input-key prompt
+   --label-key label
+   --apply-chat-template
+   --rollout-shuffle
+   --rm-type dapo
+   --reward-key score
+   --num-rollout ${NUM_ROLLOUT}
+   --rollout-batch-size 32
+   --n-samples-per-prompt 8
+   --rollout-max-response-len 8192
+   --rollout-temperature 1
+   --global-batch-size 256
+   --use-fault-tolerance
+)
+
+EVAL_ARGS=(
+   --log-passrate
+   --skip-eval-before-train
+   --eval-interval 200
+   --eval-prompt-data aime ${EXP_DIR}/aime-2024/aime-2024.jsonl
+   --n-samples-per-eval-prompt 8
+   --eval-max-response-len 8192
+   --eval-top-p 0.7
+)
+
+PERF_ARGS=(
+   --tensor-model-parallel-size 4
+   --sequence-parallel
+   --pipeline-model-parallel-size 1
+   --context-parallel-size 1
+   --expert-model-parallel-size 1
+   --expert-tensor-parallel-size 1
+   --no-gradient-accumulation-fusion
+   --recompute-granularity full
+   --recompute-method uniform
+   --recompute-num-layers 1
+
+   #--use-dynamic-batch-size
+   --qkv-format bshd
+   --max-tokens-per-gpu 10240
+   --micro-batch-size 2 # avoid OOM
+
+   --no-rope-fusion
+)
+
+GRPO_ARGS=(
+   --advantage-estimator grpo
+   # --use-kl-loss
+   --kl-loss-coef 0.00
+   --kl-loss-type low_var_kl
+   --entropy-coef 0.00
+   --eps-clip 0.2
+   --eps-clip-high 0.28
+   --use-tis
+)
+
+OPTIMIZER_ARGS=(
+   --optimizer adam
+   --lr 1e-6
+   --lr-decay-style constant
+   --weight-decay 0.1
+   --adam-beta1 0.9
+   --adam-beta2 0.98
+
+   --optimizer-cpu-offload
+   --overlap-cpu-optimizer-d2h-h2d
+   --use-precision-aware-optimizer
+)
+
+SGLANG_ARGS=(
+   --rollout-num-gpus-per-engine 2
+   --sglang-mem-fraction-static 0.8
+   --sglang-max-running-requests 256
+   --sglang-cuda-graph-bs 1 2 4 8 16 32 64 128 192 256
+   --sglang-device npu
+   --sglang-disable-radix-cache
+   --sglang-attention-backend ascend
+   --sglang-chunked-prefill-size 4096
+   --sglang-max-prefill-tokens 8192
+   --sglang-enable-dp-attention
+   --sglang-enable-dp-lm-head
+)
+
+WANDB_ARGS=(
+   --use-clearml
+   --use-metrics-service
+   --tb-project-name  ${PROJECT_NAME}
+   --tb-experiment-name qwen35-9B-8x-async-${now}
+)
+
+MISC_ARGS=(
+   # default dropout in megatron is 0.1
+   --attention-dropout 0.0
+   --hidden-dropout 0.0
+   # should be good for model performance
+   --accumulate-allreduce-grads-in-fp32
+   --attention-softmax-in-fp32
+   # need to comment this when using model with MLA
+   --attention-backend flash
+   --use-flash-attn
+)
+
+mkdir -p log
+ray job submit ${RAY_NO_WAIT:+--no-wait} --address="http://${HOST_IP}:8265" \
+   ${WORKING_DIR:+--working-dir "${WORKING_DIR}"} \
+   --runtime-env-json="${RUNTIME_ENV_JSON}" \
+   -- python3 -m relax.entrypoints.train \
+   --resource '{"actor": [1, 4], "rollout": [1, 4], "advantages": [1, 0]}'\
+   --max-staleness 2 \
+   --num-data-storage-units 1 \
+   --num-iters-per-train-update 32 \
+   --ref-actor-config '{"tensor_model_parallel_size": 1, "pipeline_model_parallel_size": 1, "expert_model_parallel_size": 1, "max_tokens_per_gpu": 10240, "sequence_parallel": false, "only_load_weight": true}' \
+   --fully-async \
+    --use-health-check \
+    "${MODEL_ARGS[@]}" \
+    "${CKPT_ARGS[@]}" \
+    "${ROLLOUT_ARGS[@]}" \
+    "${OPTIMIZER_ARGS[@]}" \
+    "${GRPO_ARGS[@]}" \
+    "${WANDB_ARGS[@]}" \
+    "${PERF_ARGS[@]}" \
+    "${EVAL_ARGS[@]}" \
+    "${SGLANG_ARGS[@]}" \
+    "${MISC_ARGS[@]}"  2>&1 | tee log/qwen35-9B-GRPO-gpu16-async-${now}.log


### PR DESCRIPTION
## Updated
- Patched Megatron, Megatron-Bridge, and MindSpeed to support training Qwen3.5-9B on Ascend NPU.
- Now `gradient-accumulation-fusioncan` be passed via arguments.
- Added `Dockerfile.npu.qwen35-9b` with all dependencies (MindSpeed, custom Sglang, etc.) and scripts to run Qwen3.5‑9B GRPO, including accuracy validation steps.

## Test
build env:
```bash
docker build -f docker/Dockerfile.npu.qwen35-9b -t tmp-20260618 .
```

execute scripts:

```bash
bash scripts/training/text/run-qwen35-9B-8xgpu-async-npu.sh
```
200step results compare with H20:
<img width="811" height="901" alt="npu-gpu-qwen35-9B" src="https://github.com/user-attachments/assets/44db5ae6-f164-40d1-b91f-a50859cdd253" />



## What

<!-- What changes does this PR introduce? -->

## Why

<!-- Why are these changes needed? Link related issues with "Fixes #123" or "Relates to #456". -->

## How

<!-- How do the changes work? Describe the technical approach. -->

## Testing

<!-- How were the changes tested? Include commands, test results, or screenshots. -->

- [ ] `pre-commit run --all-files` passes
- [ ] Tests pass (`pytest tests/`)
- [ ] New tests added (if applicable)
- [ ] Documentation updated (if applicable)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Screenshots / Logs

<!-- If applicable, add screenshots or log output to help explain the changes. -->
