### PR TITLE
fix(registry): override StrEnum.__str__ for Python 3.10 colocate dete…

### DIFF
--- a/relax/core/registry.py
+++ b/relax/core/registry.py
@@ -7,7 +7,8 @@ except ImportError:
     from enum import Enum
 
     class StrEnum(str, Enum):
-        pass
+        def __str__(self) -> str:
+            return self.value
 
 
 from relax.components.actor import Actor


### PR DESCRIPTION
…ction

## What

fix(registry): override StrEnum.__str__ for Python 3.10 colocate detection

Python 3.10 lacks enum.StrEnum, and the fallback `class StrEnum(str, Enum)`
inherits Enum.__str__, so str(ROLES.actor) yields "ROLES.actor" instead of
"actor". This broke controller.py role_names membership checks, silently
disabling colocate and doubling GPU demand (actor=8, rollout=8). Returning
self.value restores correct role-name strings.


## Testing

<!-- How were the changes tested? Include commands, test results, or screenshots. -->

- [ ] `pre-commit run --all-files` passes
- [ ] Tests pass (`pytest tests/`)
- [ ] New tests added (if applicable)
- [ ] Documentation updated (if applicable)

## Type of Change

- [ ✅] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Screenshots / Logs

<!-- If applicable, add screenshots or log output to help explain the changes. -->
