### PR TITLE
fix(wandb): add wandb init

### DIFF
--- a/relax/entrypoints/train.py
+++ b/relax/entrypoints/train.py
@@ -21,6 +21,7 @@ from relax.core.controller import Controller  # noqa: E402
 from relax.utils import telemetry  # noqa: E402
 from relax.utils.arguments import parse_args  # noqa: E402
 from relax.utils.logging_utils import get_logger  # noqa: E402
+from relax.utils.tracking_utils import init_tracking  # noqa: E402
 from relax.utils.utils import post_process_env  # noqa: E402
 
 
@@ -87,6 +88,7 @@ def main(args):
         runtime_env = yaml.safe_load(file)
 
     runtime_env = post_process_env(args, runtime_env)
+    init_tracking(args)
     if not ray.is_initialized():
         # this is for local ray cluster
         ray.init(runtime_env=runtime_env)


### PR DESCRIPTION
## What

fix wandb func don't work

## Why

ref to slime https://github.com/THUDM/slime/blob/main/train.py#L13

## How

wandb need do init, such as generator run name、group、config. then can work well.

## Testing

<!-- How were the changes tested? Include commands, test results, or screenshots. -->

- [ ] `pre-commit run --all-files` passes
- [ ] Tests pass (`pytest tests/`)
- [ ] New tests added (if applicable)
- [ ] Documentation updated (if applicable)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Screenshots / Logs

<!-- If applicable, add screenshots or log output to help explain the changes. -->
