### PR TITLE
fix(klx-scripts): update qwen3.5 training scripts for klx

### DIFF
--- a/scripts/entrypoint/spmd-multinode.sh
+++ b/scripts/entrypoint/spmd-multinode.sh
@@ -57,7 +57,7 @@ export PYTHONPATH=${RELAX}:$MEGATRON:$RELAX:${PYTHONPATH:-}
 export MODEL_CONFIG_DIR="${DIR}/../models"
 
 # ── NVLink detection ────────────────────────────────────────────────────────
-if [ -e /dev/xpuptcl ]; then
+if [ -e /dev/xpuctrl ]; then
     NVLINK_COUNT=0
 else
     NVLINK_COUNT=$(nvidia-smi topo -m 2>/dev/null | grep -o 'NV[0-9][0-9]*' | wc -l)

--- a/scripts/training/text/run-qwen3-4B-8xklx.sh
+++ b/scripts/training/text/run-qwen3-4B-8xklx.sh
@@ -250,7 +250,9 @@ RUNTIME_ENV_JSON="{
     \"XMLIR_MATMUL_FAST_MODE\": \"1\",
     \"XMLIR_ENABLE_FAST_FC\": \"1\",
     \"HYDRAX_USE_PROTEUS\": \"0\",
-    \"XSGL_INT8_LM_HEAD\": \"0\"
+    \"XSGL_INT8_LM_HEAD\": \"0\",
+    \"NVTE_DEBUG\": \"1\",
+    \"NVTE_DEBUG_LEVEL\": \"1\"
   }
 }"
 

--- a/scripts/training/text/run-qwen35-35B-A3B-16xklx.sh
+++ b/scripts/training/text/run-qwen35-35B-A3B-16xklx.sh
@@ -197,7 +197,7 @@ MISC_ARGS=(
 
 RUNTIME_ENV_JSON="{
   \"env_vars\": {
-    \"PYTHONPATH\": \"${WORKDIR}/TransferQueue:${WORKDIR}/Megatron-LM/:${SCRIPT_DIR}\",
+    \"PYTHONPATH\": \"${WORKDIR}/TransferQueue:${WORKDIR}/Megatron-LM:${WORKDIR}/Megatron-Bridge/src:${SCRIPT_DIR}:${PYTHONPATH}\",
     \"LD_LIBRARY_PATH\":\"${CONDA_PREFIX}/xcudart/lib:${CONDA_PREFIX}/lib/python3.10/site-packages/xtorch_ops:${CONDA_PREFIX}/lib/python3.10/site-packages/torch_xmlir/:${CONDA_PREFIX}/lib/python3.10/site-packages/torch_xmlir/xre/so\",
     \"CUDA_DEVICE_MAX_CONNECTIONS\": \"1\",
     \"OPENBLAS_NUM_THREADS\": \"64\",
@@ -295,7 +295,9 @@ RUNTIME_ENV_JSON="{
     \"XPU_SET_SIGMOID_GATING_DELTA_RULE_UPDATE_FP16_FAST_OPT\": \"${XPU_SET_SIGMOID_GATING_DELTA_RULE_UPDATE_FP16_FAST_OPT}\",
     \"HYDRAX_USE_PROTEUS\": \"0\",
     \"GLOO_SOCKET_IFNAME\": \"eth0\",
-    \"TP_SOCKET_IFNAME\": \"eth0\"
+    \"TP_SOCKET_IFNAME\": \"eth0\",
+    \"NVTE_DEBUG\": \"1\",
+    \"NVTE_DEBUG_LEVEL\": \"1\"
    }
 }"
 

--- a/scripts/training/text/run-qwen35-9B-8xklx.sh
+++ b/scripts/training/text/run-qwen35-9B-8xklx.sh
@@ -16,6 +16,7 @@ echo "当前时间: $now"
 export CUDA_ENABLE_P2P_NO_UVA=0
 export CUDA_FAKE_UVA_ENABLE=1
 export CUDA_ERROR_LEVEL=0
+export XMLIR_MEMCPY_RETRY_SYNC=true
 
 export XPU_SUPPORT_IPC_EVENT=1
 
@@ -60,11 +61,11 @@ ROLLOUT_ARGS=(
    --rm-type dapo
    --reward-key score
    --num-rollout ${NUM_ROLLOUT}
-   --rollout-batch-size 32
+   --rollout-batch-size 64
    --n-samples-per-prompt 8
    --rollout-max-response-len 8192
    --rollout-temperature 1
-   --global-batch-size 256
+   --global-batch-size 512
    --balance-data
    --use-fault-tolerance
 )
@@ -162,7 +163,6 @@ RUNTIME_ENV_JSON="{
   \"env_vars\": {
     \"PYTHONPATH\": \"/workspace/TransferQueue:/workspace/Megatron-LM/:/workspace/Megatron-Bridge/src/:/workspace/Relax/:$PYTHONPATH\",
     \"LD_LIBRARY_PATH\":\"${CONDA_PREFIX}/xcudart/lib:${CONDA_PREFIX}/lib/python3.10/site-packages/xtorch_ops:${CONDA_PREFIX}/lib/python3.10/site-packages/torch_xmlir/:${CONDA_PREFIX}/lib/python3.10/site-packages/torch_xmlir/xre/so\",
-    \"XMLIR_MEMCPY_RETRY_SYNC\": \"true\",
     \"CUDA_DEVICE_MAX_CONNECTIONS\": \"1\",
     \"OPENBLAS_NUM_THREADS\": \"64\",
     \"OMP_NUM_THREADS\": \"64\",
@@ -174,7 +174,6 @@ RUNTIME_ENV_JSON="{
     \"CUDA_DEVICE_ORDER\": \"OAM_ID\",
     \"CUDART_DUMMY_REGISTER\": \"1\",
     \"XPU_FORCE_USERMODE_LAUNCH\": \"1\",
-    \"XMLIR_DIST_SINGLETON_STREAM\": \"true\",
     \"CUDA_VISIBLE_DEVICES\": \"0,1,2,3,4,5,6,7\",
     \"XPU_VISIBLE_DEVICES\": \"0,1,2,3,4,5,6,7\",
     \"XMLIR_FA_GEMM_TYPE\": \"float\",
@@ -192,12 +191,11 @@ RUNTIME_ENV_JSON="{
     \"BKCL_RING_OPT\": \"1\",
     \"BKCL_FLAT_RING\": \"1\",
     \"BKCL_CCIX_RING\": \"1\",
-    \"BKCL_TREE_THRESHOLD\": \"1\",
+    \"BKCL_TREE_THRESHOLD\": \"1048576\",
     \"BKCL_CCIX_BUFFER_GM\": \"1\",
     \"BKCL_FORCE_L3_RDMA\": \"0\",
     \"BKCL_RING_BUFFER_GM\": \"1\",
     \"BKCL_ENABLE_XDR\": \"1\",
-    \"BKCL_RDMA_FORCE_TREE\": \"1\",
     \"BKCL_XLINK_D2D\": \"0\",
     \"BKCL_XLINK_ETH\": \"0\",
     \"BKCL_XLINK_C2C\": \"1\",
@@ -210,12 +208,13 @@ RUNTIME_ENV_JSON="{
     \"BKCL_TIMEOUT\": \"400000\",
     \"CUDA_DISABLE_PRINTF\": \"1\",
     \"BKCL_RDMA_VERBS\": \"1\",
-    \"BKCL_RDMA_NICS\": \"xgbe0,xgbe0,xgbe2,xgbe2,xgbe4,xgbe4,xgbe5,xgbe5\",
+    \"BKCL_RDMA_NICS\": \"eth1,eth1,eth2,eth2,eth3,eth3,eth4,eth4\",
+    \"NVTE_DEBUG\": \"1\",
+    \"NVTE_DEBUG_LEVEL\": \"1\",
     \"RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES\": \"1\",
     \"TORCH_XCCL_DEFAUTL_PG_TIMEOUT_MILSEC\": \"7200000\",
     \"CUDA_ERROR_LEVEL\": \"0\",
     \"HYDRA_FULL_ERROR\": \"1\",
-    \"XMLIR_ENABLE_NEW_PG\": \"1\",
     \"TORCH_XCCL_HEARTBEAT_TIMEOUT_SEC\": \"1800\",
     \"TORCH_XCCL_ENABLE_TIMING\": \"1\",
     \"TORCH_FR_BUFFER_SIZE\": \"2000\",
@@ -224,29 +223,29 @@ RUNTIME_ENV_JSON="{
     \"BKCL_ALL_TO_ALL_OPT\": \"1\",
     \"SGLANG_IS_FLASHINFER_AVAILABLE\": \"false\",
     \"USE_MOE_FC_V3\": \"1\",
-    \"XMLIR_DIST_SINGLETON_STREAM\": \"1\",
-    \"XMLIR_USE_HYDRA_LINEAR\": \"0\",
-    \"SGL_CPU_QUANTIZATION\": \"0\",
-    \"XSGL_ENABLE_MEM_SAVER\": \"0\",
-    \"XPU_ENABLE_CTX_LAZY_INIT\": \"1\",
-    \"XPU_SUPPORT_IPC_EVENT\": \"1\",
-    \"XSGL_USE_TORCH_CAUSAL_CONV\": \"1\",
-    \"TRACE_WEIGHT_PATHS\": \"0\",
-    \"TRITON_SKIP_AUTOTUNE\": \"1\",
     \"FLA_USE_NAIVE\": \"1\",
     \"FORCE_DISABLE_FLA\": \"1\",
-    \"DUMP_CONVERTED_WEIGHTS_DIR\": \"\",
     \"DISABLE_CAST_CACHE\": \"1\",
-    \"FORCE_NN_LINEAR\": \"1\",
-    \"USE_FUSED_GATED_DELTA_RULE\": \"1\",
+    \"FORCE_NN_LINEAR\": \"0\",
+    \"XMLIR_USE_HYDRA_LINEAR\": \"1\",
+    \"SGL_CPU_QUANTIZATION\": \"1\",
+    \"XPU_ENABLE_CTX_LAZY_INIT\": \"1\",
+    \"XPU_SUPPORT_IPC_EVENT\": \"1\",
+    \"TRITON_SKIP_AUTOTUNE\": \"1\",
+    \"XMLIR_FORCE_USE_XPU_GRAPH\": \"1\",
+    \"XSGL_USE_TORCH_CAUSAL_CONV\": \"1\",
+    \"XSGL_FUSE_SPLIT_NORM_ROPE_NEOX\": \"1\",
+    \"XPU_FLASH_ATTENTION_DECODER_USE_BALANCE\": \"1\",
+    \"CUDA_ENABLE_P2P_NO_UVA\": \"0\",
+    \"CUDA_FAKE_UVA_ENABLE\": \"1\",
     \"XSGL_TRANSPOSE_SSM_STATE\": \"1\",
     \"XSGL_TRANSPOSE_CONV_STATE\": \"1\",
-    \"XSGL_FUSE_SPLIT_NORM_ROPE_NEOX\": \"1\",
-    \"XSGL_MOE_UNSTABLE_TOPK\": \"1\",
-    \"XPU_FLASH_ATTENTION_DECODER_USE_BALANCE\": \"1\",
-    \"XMLIR_FORCE_USE_XPU_GRAPH\": \"1\",
+    \"USE_FUSED_GATED_DELTA_RULE\": \"1\",
     \"RAY_OVERRIDE_JOB_RUNTIME_ENV\":\"1\",
-    \"HYDRAX_USE_PROTEUS\": \"0\",
+    \"XMLIR_D_XPU_L3_SIZE\": \"0\",
+    \"XMLIR_MEMCPY_RETRY_SYNC\": \"true\",
+    \"DEBUG_DUMP_TOKENS\": \"0\",
+    \"RELAX_SKIP_TORCH_MEMORY_SAVER\":\"1\",
     \"XMLIR_MATMUL_FAST_MODE\": \"1\",
     \"XMLIR_ENABLE_FAST_FC\": \"1\",
     \"HYDRAX_USE_PROTEUS\": \"0\",


### PR DESCRIPTION
## What

Fix Qwen3.5 series model training scripts for KLX (Kunlun XPU) to make them run correctly.

- **`run-qwen35-9B-8xklx.sh`**: Overhaul runtime env vars, increase batch sizes (rollout: 32→64, global: 256→512), fix RDMA NIC names (`xgbe*` → `eth*`), add stability variables like `XMLIR_MEMCPY_RETRY_SYNC`, remove stale/conflicting env vars
- **`run-qwen35-35B-A3B-16xklx.sh`**: Fix `PYTHONPATH` to include `Megatron-Bridge/src`
- **`run-qwen3-4B-8xklx.sh`**: Add `NVTE_DEBUG` diagnostic variables
- **`spmd-multinode.sh`**: Fix XPU device detection path (`/dev/xpuptcl` → `/dev/xpuctrl`)
## Why

Several misconfigurations in the KLX scripts prevented training from starting or caused instability:
- Typo in `/dev/xpuptcl` device path caused incorrect NVLink detection logic
- Missing `Megatron-Bridge/src` in `PYTHONPATH` caused module import failures
- RDMA NIC names (`xgbe*`) did not match actual cluster interfaces (`eth*`)
- Several env vars were misconfigured or conflicting (e.g. `BKCL_TREE_THRESHOLD`, `FORCE_NN_LINEAR`, `XMLIR_USE_HYDRA_LINEAR`)

## How

Directly modified the training launch scripts for each model.

## Testing

Validated by submitting actual training jobs on the KLX cluster.

- [ ] `pre-commit run --all-files` passes
- [ ] Tests pass (`pytest tests/`)
- [ ] New tests added (if applicable)
- [ ] Documentation updated (if applicable)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] CI/CD or build changes

## Screenshots / Logs

N/A
