### PR TITLE
Fix SGLang PD bootstrap TP size inference

### DIFF
--- a/docker/patch/latest/sglang.patch
+++ b/docker/patch/latest/sglang.patch
@@ -81,13 +81,17 @@ index bc21f8882..87329e5a0 100644
                              return
  
                  self.bootstrap_infos = bootstrap_infos
-@@ -826,8 +847,13 @@ class CommonKVBootstrapServer(BaseKVBootstrapServer):
+@@ -826,8 +847,17 @@ class CommonKVBootstrapServer(BaseKVBootstrapServer):
                      f" ({self._registered_count} workers registered).",
                      status=503,
                  )
-+            
++
 +            inferred_attn_tp_size = max(
-+                (len(v) for v in self.prefill_port_table.values()),
++                (
++                    len(tp_group_table)
++                    for dp_group_table in self.prefill_port_table.values()
++                    for tp_group_table in dp_group_table.values()
++                ),
 +                default=self.attn_tp_size,
 +            )
              info = PrefillServerInfo(


### PR DESCRIPTION
## 问题说明

Relax 的 Docker 构建会基于 SGLang `update-transformers-v5` 分支应用 `docker/patch/latest/sglang.patch`。当前 patch 中，PD bootstrap 阶段推断 `attn_tp_size` 的逻辑是：

```python
inferred_attn_tp_size = max(
    (len(v) for v in self.prefill_port_table.values()),
    default=self.attn_tp_size,
)
```

但 `prefill_port_table` 的结构实际是：

```text
dp_group -> cp_rank -> tp_rank -> pp_rank -> PrefillRankInfo
```

因此 `len(v)` 统计到的是每个 DP group 下的 CP rank 数量，而不是 TP rank 数量。

在 TP > 1、CP = 1 的 PD 分离部署场景下，这会把 `attn_tp_size` 错误推断为 `1`。例如 TP=8/CP=1 时，decode 侧拿到的 prefill server topology 会和真实 TP 拓扑不一致，可能导致端到端请求卡在 decode/detokenizer 附近，表现为请求无法正常返回。

## 解决办法

修正 `attn_tp_size` 的推断维度，进入 `prefill_port_table` 的下一层，统计每个 CP rank 下的 TP group 数量：

```python
inferred_attn_tp_size = max(
    (
        len(tp_group_table)
        for dp_group_table in self.prefill_port_table.values()
        for tp_group_table in dp_group_table.values()
    ),
    default=self.attn_tp_size,
)
```

这样可以正确按照 `tp_rank` 维度推断 `attn_tp_size`，避免 PD prefill/decode 两侧看到的拓扑信息不一致。

## 验证

- 已验证 `docker/patch/latest/sglang.patch` 可以 clean apply 到 `sgl-project/sglang:update-transformers-v5`。
- 已验证应用 patch 后，生成的 `conn.py` 中使用 `len(tp_group_table)` 推断 TP size，不再使用原来的 `len(v)` 逻辑。
- 该改动仅修正 PD bootstrap 阶段的 TP size 推断逻辑，不改变其他 PD/Mooncake 传输逻辑。