### PR TITLE
fix(test): CI collection and add GitHub sync gate

### DIFF
--- a/examples/deepeyes_v2_agentic/app/agent.py
+++ b/examples/deepeyes_v2_agentic/app/agent.py
@@ -27,7 +27,6 @@ from app.env_deepeyes_v2 import (
     extract_tool_call,
 )
 from app.sandboxes import SandboxExecutor, get_sandbox_backend
-from openai import APIStatusError, AsyncOpenAI
 from PIL import Image
 
 
@@ -136,6 +135,8 @@ def _build_executor(backend_name: str, ensure_sandbox_timeout_s: int) -> Sandbox
 
 
 async def run_session(messages: list[dict[str, Any]], metadata: dict[str, Any]) -> dict[str, Any]:
+    from openai import APIStatusError, AsyncOpenAI  # type: ignore[import-not-found]
+
     config = yaml.safe_load(CONFIG_PATH.read_text(encoding="utf-8"))
     max_turns = int(config["max_turns"])
     ensure_sandbox_timeout_s = int(config["ensure_sandbox_timeout_s"])

--- a/skills/sync-github/SKILL.md
+++ b/skills/sync-github/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sync-github
-description: Use when syncing Relax code between internal GitLab and external GitHub, especially gitlab/dev, gitlab/main, github/main, internal CR/MR handoff, linear main history, sensitive-content checks, or guarded GitHub pushes.
+description: Use when syncing Relax code between internal GitLab and external GitHub, especially gitlab/dev, gitlab/main, github/main, internal CR/MR handoff, linear main history, sensitive-content checks, GitHub Actions CI validation, or guarded GitHub pushes.
 ---
 
 # sync-github
@@ -61,7 +61,47 @@ git status --porcelain --untracked-files=no
 
 ## GitHub Push 门禁
 
-任何 GitHub push 前都要输出并暂停：
+任何推送到 `github/main` 前，必须先完成 GitHub Actions main push 门禁。普通功能分支 / 验证分支 push 只用于触发 CI，不等同于允许推送 `github/main`。
+
+### GitHub Actions main push 门禁
+
+`gh workflow run` 只会运行 GitHub 上已经 push 的代码，不会包含本地未提交或未 push 的改动。`ci.yml` 目前只能触发整个 workflow，不能只跑其中一个 job，除非 workflow 自己添加 inputs 控制。
+
+在准备 `git push github HEAD:refs/heads/main` 前，必须：
+
+```bash
+test -z "$(git status --porcelain --untracked-files=no)"
+SOURCE_SHA=$(git rev-parse HEAD)
+VALIDATE_BRANCH=sync/validate-github-main-$(git rev-parse --short HEAD)
+git push github HEAD:refs/heads/$VALIDATE_BRANCH
+gh workflow run ci.yml -R redai-infra/Relax --ref $VALIDATE_BRANCH
+gh run list -R redai-infra/Relax --workflow ci.yml --branch $VALIDATE_BRANCH --limit 5
+gh run watch <run-id> -R redai-infra/Relax
+gh run view <run-id> -R redai-infra/Relax --json status,conclusion,headSha,url
+```
+
+门禁规则：
+
+- `headSha` 必须等于 `SOURCE_SHA`，否则该 CI 结果不能作为本次 `github/main` push 凭证。
+- `conclusion` 必须是 `success`，且至少包含 `Pre-commit Checks`、`Lint`、Python 测试矩阵全部成功。
+- 如果失败，先查看失败日志：
+
+```bash
+gh run view <run-id> -R redai-infra/Relax --log-failed
+```
+
+- 如果需要改代码：本地修复、提交、push 到同一个验证分支或新验证分支后，重新 `gh workflow run ci.yml`。不要用旧 run 证明新代码。
+- 如果确认是瞬时失败且代码未变，可以只重跑失败 job：
+
+```bash
+gh run rerun <run-id> -R redai-infra/Relax --failed
+```
+
+- 在 CI 全绿前禁止执行 `git push github HEAD:refs/heads/main`。
+
+### 最终 GitHub push 暂停
+
+GitHub Actions main push 门禁全绿后，任何 `github/main` push 前都要输出并暂停：
 
 ```text
 准备执行 GitHub push：
@@ -70,7 +110,8 @@ git status --porcelain --untracked-files=no
 source ref / SHA: <...>
 target ref / 当前 SHA: <...>
 fast-forward: <yes|no|not-applicable>
-安全检查: <gitleaks/pre-commit 结果>
+安全检查: <duplicate-def / F811 / gitleaks 结果>
+GitHub Actions: <ci.yml run url> / <success> / <headSha>
 
 请回复：确认执行 GitHub push
 ```

--- a/skills/sync-github/references/prompt-b-dev-to-main.md
+++ b/skills/sync-github/references/prompt-b-dev-to-main.md
@@ -22,6 +22,7 @@
 9. 已跟踪文件有本地改动时停止；只有未跟踪文件时，记录路径并继续。不要删除、stage、stash、clean 未跟踪文件。
 10. 不要运行需要 GPU 的代码或测试。
 11. 如果缺少 `gitleaks`，读取 `references/gitleaks.md`，向用户确认安装方案后再继续。
+12. 推送 `github/main` 前必须先把同一个 `HEAD` push 到 GitHub 验证分支，手动触发 `ci.yml`，并确认该 run 的 `headSha` 等于本地 `HEAD` 且结论为 `success`。
 
 ## 0. 重新拉取状态
 
@@ -157,7 +158,65 @@ git fetch gitlab --prune
 test "$(git rev-parse gitlab/main)" = "$(git rev-parse HEAD)"
 ```
 
-## 6. 普通 push 到 GitHub main
+## 6. GitHub Actions main push 门禁
+
+`gh workflow run` 跑的是 GitHub 上已经 push 的代码，不会带本地未提交或未 push 的改动。因此必须先把准备推到 `github/main` 的同一个 `HEAD` 推到 GitHub 验证分支，再手动触发远端 CI。
+
+确认本地 tracked 工作区干净，并记录源 SHA：
+
+```bash
+test -z "$(git status --porcelain --untracked-files=no)"
+SOURCE_SHA=$(git rev-parse HEAD)
+VALIDATE_BRANCH=sync/validate-github-main-$(git rev-parse --short HEAD)
+```
+
+推送验证分支并触发完整 `ci.yml`：
+
+```bash
+git push github HEAD:refs/heads/$VALIDATE_BRANCH
+gh workflow run ci.yml -R redai-infra/Relax --ref $VALIDATE_BRANCH
+gh run list -R redai-infra/Relax --workflow ci.yml --branch $VALIDATE_BRANCH --limit 5
+```
+
+选中刚触发的 run id 后盯住它：
+
+```bash
+gh run watch <run-id> -R redai-infra/Relax
+gh run view <run-id> -R redai-infra/Relax --json status,conclusion,headBranch,headSha,url
+```
+
+门禁规则：
+
+- `headBranch` 必须等于 `$VALIDATE_BRANCH`。
+- `headSha` 必须等于 `$SOURCE_SHA`。
+- `conclusion` 必须等于 `success`。
+- `Pre-commit Checks`、`Lint`、`Tests (Python 3.10)`、`Tests (Python 3.11)`、`Tests (Python 3.12)` 必须全部成功。
+
+如果失败，先看失败日志：
+
+```bash
+gh run view <run-id> -R redai-infra/Relax --log-failed
+```
+
+处理规则：
+
+- 如果需要改代码：本地修复、提交、push 到验证分支后，重新 `gh workflow run ci.yml`。旧 run 不能证明新代码。
+- 如果确认是瞬时失败且代码未变，可以只重跑失败 job：
+
+```bash
+gh run rerun <run-id> -R redai-infra/Relax --failed
+```
+
+CI 没有全绿前，禁止执行下一步 `git push github HEAD:refs/heads/main`。
+
+记录：
+
+- 验证分支名
+- `SOURCE_SHA`
+- `ci.yml` run id 和 URL
+- `status` / `conclusion` / `headSha`
+
+## 7. 普通 push 到 GitHub main
 
 先确认是 fast-forward：
 
@@ -175,6 +234,7 @@ source ref / SHA: HEAD / $(git rev-parse HEAD)
 target ref / 当前 SHA: refs/heads/main / $(git rev-parse github/main)
 fast-forward: yes
 安全检查: <duplicate-def / F811 / gitleaks 结果>
+GitHub Actions: <ci.yml run url> / success / <headSha>
 
 请回复：确认执行 GitHub push
 ```
@@ -185,7 +245,7 @@ fast-forward: yes
 git push github HEAD:refs/heads/main
 ```
 
-## 7. 最终验证
+## 8. 最终验证
 
 重新 fetch：
 
@@ -206,6 +266,7 @@ test "$(git rev-parse gitlab/main)" = "$(git rev-parse github/main)"
 - 本次同步 cherry-pick 的有效 commit 列表
 - 跳过的空提交 / GitLab merge / 无效 merge commit 列表
 - duplicate-def / ruff F811 / gitleaks 检查结果
+- GitHub Actions `ci.yml` 验证分支、run id、run URL、headSha、conclusion
 - 本地 `sync/*` 临时分支若存在，只是旧流程遗留；Prompt B 不应再创建新的同步分支
 
 ## 异常处理


### PR DESCRIPTION
## Summary
- Defer the DeepEyes V2 OpenAI SDK import so helper tests do not require the optional SDK during collection.
- Document the GitHub Actions validation-branch gate before pushing to github/main in the sync-github skill.

## Verification
- PATH=/tmp/relax-bifrost-ci-venv/bin:$PATH pre-commit run --all-files --show-diff-on-failure
- /tmp/relax-bifrost-ci-venv/bin/pytest tests/examples/deepeyes_v2_agentic/test_agent_messages.py -v --tb=short
- gh workflow run ci.yml -R redai-infra/Relax --ref codex/fix-main-tests
- gh run watch 28846598709 -R redai-infra/Relax