### PR TITLE
fix(opd): align plain opd VLM teacher token length

### DIFF
--- a/relax/utils/opd/opd_opsd_worker.py
+++ b/relax/utils/opd/opd_opsd_worker.py
@@ -22,7 +22,9 @@ class OpsdWorker:
     def from_args(cls, args) -> "OpsdWorker":
         teacher_prompt_key = getattr(args, "opd_teacher_prompt_key", None)
         teacher_image_key = getattr(args, "opd_teacher_image_key", None)
-        return cls(is_opsd=teacher_prompt_key is not None or teacher_image_key is not None)
+        multimodal_keys = getattr(args, "multimodal_keys", None) or {}
+        uses_student_images = "image" in multimodal_keys
+        return cls(is_opsd=teacher_prompt_key is not None or teacher_image_key is not None or uses_student_images)
 
     async def build_teacher_inputs(self, args, sample: "Sample") -> None:
         """Pre-expand teacher inputs on the client (rollout) side.
@@ -52,6 +54,8 @@ class OpsdWorker:
             # logprob requests use the pre-expanded path and logprob_start_len
             # stays aligned with SGLang.
             if sample.tokens and int(sample.response_length or 0) > 0:
+                sample.teacher_tokens = list(sample.tokens)
+                sample.teacher_prompt_length = len(sample.tokens) - int(sample.response_length)
                 student_mm_train_inputs = getattr(sample, "multimodal_train_inputs", None)
                 student_grid_thw = (student_mm_train_inputs or {}).get("image_grid_thw")
                 student_mm_in = sample.multimodal_inputs or {}


### PR DESCRIPTION
## Summary

Activate `OpsdWorker` for plain VLM OPD without teacher-specific prompt or image keys so the teacher reuses the student's expanded tokens and matching prompt length.

The issue is triggered by running the plain VLM OPD recipe:

```bash
bash scripts/entrypoint/spmd-multinode.sh \
  examples/on_policy_distillation/vision_opd/run-opd-qwen3.5_35ba3b-122ba10b-128xgpu-colocate.sh
```

This recipe configures student images through `--multimodal-keys` but intentionally omits teacher-specific prompt and image keys.

## Example

Given:

```text
prompt                = [10, <image>]
response              = [20, 21]
sample.rollout_tokens = [10, 99, 20, 21]          # collapsed image placeholder
sample.tokens         = [10, 99, 99, 99, 20, 21]  # expanded image placeholder
response_length       = 2
```

The expanded prompt has four tokens, so Relax calculates `logprob_start_len = 4 - 1 = 3`. With the correct six-token expanded input, SGLang returns positions 3–5: one boundary log probability plus two response log probabilities, matching `response_length + 1 = 3`.

Before the fix, Relax sent the four-token collapsed input with the same start offset of 3 and no `image_data`. Only position 3 remained, so the teacher returned one log probability instead of three and failed prefill validation.

## Fix

- Activate `OpsdWorker` when `multimodal_keys` contains `image`.
- Use `sample.tokens` as `teacher_tokens` for plain OPD.
- Calculate the teacher prompt length as `len(sample.tokens) - response_length` and reuse the existing student image payload.
